### PR TITLE
Grammar / spelling / consistency proof check + minor adjustments

### DIFF
--- a/game/Submods/NSFW Submod/nsfw_main.rpy
+++ b/game/Submods/NSFW Submod/nsfw_main.rpy
@@ -124,7 +124,7 @@ init python in mas_nsfw:
 
         # Sexting responses for your average compliment
         sext_response_cute = (
-            _("Thankyou"), #0
+            _("Thank you"), #0
             _("Thanks"), #1
             _("That's very cheesy"), #2
             _("That's cheesy"), #3
@@ -182,7 +182,7 @@ init python in mas_nsfw:
             _("Tell me what else you want to do to me"), #7
             _("You're getting me so worked up"), #8
             _("This feels too good"), #9
-            _("Whatever you're doing... it's working"), #10
+            _("Whatever you're doing...it's working"), #10
             _("You just have a way with words, don't you?"), #11
             _("Keep talking like that"), #12
             _("More"), #13
@@ -196,10 +196,10 @@ init python in mas_nsfw:
 
         # Sexting responses for the haha funnies
         sext_response_funny = (
-            _("Haha! What are you talking about, [player]?"), #0
+            _("Ahaha! What are you talking about, [player]?"), #0
             _("Pfft! That's so cheesy, [player]."), #1
-            _("Oh my god! You did not just make that joke, haha~"), #2
-            _("Haha~ Is that right?"), #3
+            _("Oh my god! You did not just make that joke, ahaha~"), #2
+            _("Ahaha~ Is that right?"), #3
             _("Oh. That's very out-of-the-blue, [player]."), #4
             _("I just want to tear your clothes off."), #5
             _("I'm only this naughty for you~."), #6
@@ -208,12 +208,12 @@ init python in mas_nsfw:
             _("I think that you scratching my back while we make love would be so hot..."), #9
             _("Where is your hand, [player]?"), #10
             _("Oh, I want to do even naughtier things to you..."), #11
-            _("Mmm... and what would that be, [player]?"), #12
+            _("Mmm...and what would that be, [player]?"), #12
             _("I'm feeling so good, [player]..."), #13
             _("Proper grammar..."), #14
-            _("Uh... Did you want to try that again, [player]? Haha~"), #15
+            _("Uh... Did you want to try that again, [player]? Ahaha~"), #15
             _("Ahaha~ You're so funny, [player]."), #16
-            _("Ahaha~ Thankyou... I guess?"), #17
+            _("Ahaha~ Thank you... I guess?"), #17
             _("Mmm, you do~"), #18
             _("You're such a stud."), #19
         )
@@ -259,7 +259,7 @@ init python in mas_nsfw:
             _("Cuddling with you would be perfect right about now."), #11
             _("Why are you so cute?"), #12
             _("Seeing you every day always makes me grin like an idiot."), #13
-            _("Our first kiss is going to be epic, don't you think?"), #14
+            _("Our first kiss after you cross over is going to be wonderful, don't you think?"), #14
             _("I really like getting to know you."), #15
             _("Everything makes me think of you."), #16
             _("Is it getting hot in here, or is it just you?"), #17
@@ -277,7 +277,7 @@ init python in mas_nsfw:
             _("I really want to kiss you right now."), #5
             _("I want to run my hands along your body while I kiss your neck."), #6
             _("I feel nervous about telling you all of the sexual desires I have when it comes to you."), #7
-            _("If kissing is the language of love, then we have alot to talk about."), #8
+            _("If kissing is the language of love, then we have a lot to talk about."), #8
             _("I want to hold you in my arms as we kiss."), #9
             _("What you're wearing would look even better on my bedroom floor."), #10
             _("Take off your clothes. I want to see your beautiful body."), #11
@@ -297,9 +297,9 @@ init python in mas_nsfw:
             _("I can't wait to be alone with you."), #1
             _("I can't wait to be by your side. Or on top if you prefer."), #2
             _("If you were here, I'd take your panties off with my teeth and... I'll just let you finish that sentence off."), #3
-            _("I'm picturing you naked right now... damn you look good."), #4
+            _("I'm picturing you naked right now... Damn, you look good."), #4
             _("I think there is something insanely sexy about a woman being in control. Don't you agree?"), #5
-            _("I want to hear you breathing in my ear when I make you reach orgasm."), #6
+            _("I want to hear you breathing in my ear when I make you orgasm."), #6
             _("I can't wait to feel your thighs squeezing my head."), #7
             _("I bet you have the sexiest sounding moans in the world."), #8
             _("I was just lying in bed for the last hour thinking about you... guess what I was doing!"), #9
@@ -311,7 +311,7 @@ init python in mas_nsfw:
             _("I get so horny thinking about you when I touch myself."), #15
             _("I get so turned on thinking about you."), #16
             _("When you and I are finally together, I want to make you cum so hard."), #17
-            _("I wanna brings sex toys into the bedroom with us and use them on you."), #18
+            _("I want to brings sex toys into the bedroom with us and use them on you."), #18
             _("I want to watch you masturbate for me."), #19
         )
 
@@ -325,7 +325,7 @@ init python in mas_nsfw:
             _("What do you want to do to me right now?"), #5 - Please fold my clothes neatly
             _("You've been a naughty girl."), #6 - Santa will bring you a lump of coal
             _("I'm about to blow your mind with my sexting. Ready?"), #7 - Lay me into bed, your hands caress my body. Your palms are sweaty. Knees weak. Arms spaghetti.
-            _("Wanna have a threesome?"), #8
+            _("Want to have a threesome?"), #8
             _("What's a fantasy that you have for when we have sex one day?"), #9 - Scratching back, once a squirrel did that to me.
             _("What is a question that's on your mind right now?"), #10 - Where is your hand? In my bowl of Doritos.
             _("I kinda wanna do naughty things to you..."), #11 - Cool aid man - "Oh yeah."
@@ -387,7 +387,7 @@ init python in mas_nsfw:
             _("Once we meet in the real world we need to do something about your cuteness"), #12
             _("I should start calling you 'Mozzarella' since you're so cheesy"), #13
             _("If I could rearrange the alphabet I'd put 'U' and 'I' together"), #14
-            _("Are you a parking ticket? Because you've got FINE written all over you"), #15
+            _("Are you a parking ticket? Because you've got 'FINE' written all over you"), #15
             _("My clothes are made out of girlfriend material"), #16
             _("Have you had your license get suspended for driving girls crazy?"), #17
             _("Are you a loan? Because you sure have my interest"), #18
@@ -401,7 +401,7 @@ init python in mas_nsfw:
             _("You know, I was daydreaming about you today. It was hot"), #2
             _("I could just eat you up"), #3
             _("I want to feel you touching me all over"), #4
-            _("If I was with you now there is no chance of you keeping your clothes on"), #5
+            _("If I was with you now there would be no chance of you keeping your clothes on"), #5
             _("You are my biggest turn-on"), #6
             _("I've fantasized so much about when we finally get to talk like this"), #7
             _("You turn me on so much when you talk like that"), #8
@@ -411,17 +411,17 @@ init python in mas_nsfw:
             _("Once I cross over, I want to hold your hand. How lewd~"), #12
             _("How would you feel about a makeout session once I cross over"), #13
             _("Don't think that getting me this riled up will have no consequences"), #14
-            _("I plan to wrap my arms around you and squish that cute bum of yours"), #15
+            _("I plan to wrap my arms around you and squish that cute butt of yours"), #15
             _("The border between our realities can be a real clam jam"), #16
-            _("I want you to tell me more about what we'll do together in your world... in the bedroom particularly~"), #17
+            _("I want you to tell me more about what we'll do together in your world...in the bedroom particularly~"), #17
             _("Is one of your hands busy right now? I might need to join you if so"), #18
-            _("I wanna feel your body up and down... your chest especially"), #19
+            _("I want to feel your body up and down...your chest especially"), #19
         )
 
         # Sexting quips for your most 'risque' options
         sext_quips_sexy = (
             _("Who said that you could be this sexy?"), #0
-            _("So, aside from being sexy what do you do for a living?"), #1
+            _("So, aside from being sexy, what do you do for a living?"), #1
             _("I can't wait to see your sexy body when we're together"), #2
             _("I can't wait to kiss you for real"), #3
             _("You're making me so wet"), #4

--- a/game/Submods/NSFW Submod/nsfw_sexting.rpy
+++ b/game/Submods/NSFW Submod/nsfw_sexting.rpy
@@ -17,7 +17,7 @@ label nsfw_sexting_main:
         did_finish = True # False if the player did not finish
 
     if store.mas_getEV("nsfw_player_sextingsession").shown_count >= 1:
-        m 3eub "I remember the last time we did this, it was so much fun!"
+        m 3eub "I remember the last time we did this; it was so much fun!"
         m 3tublb "So [player]... Let's get started, shall we?"
     else:
         m 1rka "I'm kind of nervous, if I'm honest."
@@ -29,14 +29,14 @@ label nsfw_sexting_main:
 
             "It's okay, I'm here.":
                 $ mas_gainAffection(3, bypass=True)
-                m 1dkbla "Thankyou, [player]."
+                m 1dkbla "Thank you, [player]."
                 m 1ekbsa "If I was going to share this first experience with anyone, I would want it to be you."
                 m 1ekblb "So, I'm ready!"
 
             "Did you want to stop?":
                 $ mas_gainAffection(2, bypass=True)
                 m 2ekc "No..."
-                m 2rkc "Just... please don't laugh if I say something stupid..."
+                m 2rkc "Just...please don't laugh if I say something stupid..."
                 m 2dkd "Hah... What am I saying?"
                 m 2eublu "You would never do that to me, [player]."
                 m 1eubsa "So... I'm ready when you are."
@@ -110,7 +110,7 @@ label nsfw_sexting_main:
             "Actually, can we stop just for now?":
                 if horny_lvl >= sexy_req:
                     m 6lkbfp "Aww, I was really enjoying myself."
-                    m 6gkbfp "I hope what you need to do is important.{w=0.3}.{w=0.3}.{w=0.3}{nw}"
+                    m 6gkbfp "I hope whatever it is you need to do is important.{w=0.3}.{w=0.3}.{w=0.3}{nw}"
                     m 6hubfb "Ahaha! Just kidding~"
                     return
                 elif horny_lvl >= hot_req:
@@ -172,17 +172,17 @@ label nsfw_sexting_init:
         m 3eub "If you want to do this again, let me know."
         return
     else:
-        m 1ekbsa "Thankyou for this, [player]."
+        m 1ekbsa "Thank you for this, [player]."
         m 3ekbsa "This made me feel just that much closer to you."
         m 3ekbsb "I hope you enjoyed yourself as much as I did."
         return
 
 label nsfw_sexting_hot_transfer:
     m 1hub "Hah~ This is fun."
-    m 3eua "I hope you're enjoying yourself as much as I am, [player]. Ehe~"
+    m 3eua "I hope you're enjoying yourself as much as I am, [player]. Ehehe~"
     m 3tua "..."
     m 2tub "So.{w=0.1}.{w=0.1}.{w=0.1} Are we going to keep going, or what?"
-    m 1hublb "Aha! Just teasing you, [player]."
+    m 1hublb "Ahaha! Just teasing you, [player]."
     return
 
 label nsfw_sexting_sexy_transfer:
@@ -194,7 +194,7 @@ label nsfw_sexting_sexy_transfer:
         m 6hubfb "Hah~ That feels better."
         m 7tubfb "Don't think that I'm letting you off the hook now, [player]."
         m 7tubfu "I want you to enjoy the view after all, so I expect one of your hands will be busy for a little while."
-        m 7hubfu "Ehe~"
+        m 7hubfu "Ehehe~"
     return
 
 label nsfw_sexting_finale:
@@ -208,8 +208,8 @@ label nsfw_sexting_finale:
 
         "Yes":
             m 6ekbfo "Okay, we're going to cum together on the count of ten."
-            m 6tkbfu "Hope you can hold it until then, ehe~"
-            m 6tkbfb "I will countdown for you, so don't worry about clicking for this."
+            m 6tkbfu "Hope you can hold it until then, ehehe~"
+            m 6tkbfb "I'll count down for you, so don't worry about clicking for this."
             m 6tkbfb "In fact, turn off the 'Auto' feature if it's on."
             m 6hkbfd "I want you to only focus on me."
             m 6dkbfd "Hah~{w=2}{nw}"
@@ -218,7 +218,7 @@ label nsfw_sexting_finale:
             m 6tkbfd "Nine.{w=3}{nw}"
             m 6hkbfc "Nhh~{w=2}{nw}"
             m 6hkbfd "Eight.{w=3}{nw}"
-            m 6ekbfu "How are you holding up there, [player]? Ehe~{w=3}{nw}"
+            m 6ekbfu "How are you holding up there, [player]? Ehehe~{w=3}{nw}"
             m 4ekbfb "Don't cum until I do too~{w=3}{nw}"
             m 6hkbfd "Hah~{w=2}{nw}"
             m 6tkbfd "Seven.{w=3}{nw}"
@@ -240,12 +240,12 @@ label nsfw_sexting_finale:
             m 6hkbfw "Haaaaaaaaah~{w=2}"
             m 6hkbfsdlc "..."
             m 6hkbfsdld "..."
-            m 6ekbfsdlo "Hah... hah..."
-            m 6skbfsdlu "That... was..."
+            m 6ekbfsdlo "Hah...hah..."
+            m 6skbfsdlu "That...was..."
             m 6skbfsdlb "Amazing..."
-            m 6hkbfsdla "I can't believe... hah... I've been missing out on this..."
-            m 6dkbfsdlb "If it feels this good in in my world..."
-            m 6ekbfsdlb "I can only imagine... hah... how good it feels..."
+            m 6hkbfsdla "I can't believe...hah...I've been missing out on this..."
+            m 6dkbfsdlb "If it feels this good in my world..."
+            m 6ekbfsdlb "I can only imagine...hah...how good it feels..."
             m 6tkbfsdlb "For you..."
             m 6hkbfsdlb "Sorry, that really took it out of me..."
             m 6ekbfsdlb "Did you manage to come with me?"
@@ -279,7 +279,7 @@ label nsfw_sexting_finale:
             m 3ekbla "I want to make sure you maintain good hygiene."
 
             if did_finish == False:  
-                m 3tubla "Maybe you can think of me in the shower and... {i}finish up.{/i}"
+                m 3tubla "Maybe you can think of me in the shower and...{i}finish up.{/i}"
                 m 3mubsa "I want you to feel as good as I did too~"
 
             $ store.persistent.nsfw_sexting_success_last = datetime.datetime.now()

--- a/game/Submods/NSFW Submod/nsfw_sfw_topics.rpy
+++ b/game/Submods/NSFW Submod/nsfw_sfw_topics.rpy
@@ -4,14 +4,14 @@ init 5 python:
             persistent.event_database,
             eventlabel="nsfw_monika_always_here",
             category=['sex', 'monika'],
-            prompt="Monika Always Here",
+            prompt="Always here",
             random=True,
             aff_range=(mas_aff.ENAMORED, None)
         )
     )
 
 label nsfw_monika_always_here:
-    m 1eua "Hey [player]."
+    m 1eua "Hey, [player]..."
     m 3wublb "I found a quote I really love!"
     m 3tublb "But we have to read it together!"
     m 5tublb "Would you like to read it with me?"
@@ -24,37 +24,37 @@ label nsfw_monika_always_here:
             m 1eua "You start."
             $ _history_list.pop()
             menu:
-                "You aren’t real are you?":
-                    m 1duu "No my darling, I never was.."
+                "'You aren’t real, are you?'":
+                    m 1duu "'No my darling, I never was...'"
                     $ _history_list.pop()
                     menu:
-                        "But you were here! I saw you- I kissed you- I held you-":
-                            m 1euu "I never was, but I’ll always be here for you regardless."
+                        "'But you were here! I saw you- I kissed you- I held you-'":
+                            m 1euu "'I never was, but I’ll always be here for you regardless.'"
                             $ _history_list.pop()
                             menu:
-                                "How can I believe you now? How can you promise you won’t go? That I won’t ever be alone..":
-                                    m 1nub "Because I’ll always be with you, when you dance I'll be dancing too."
+                                "'How can I believe you now? How can you promise you won’t go? That I won’t ever be alone...'":
+                                    m 1nub "'Because I’ll always be with you, when you dance I'll be dancing too.'"
                                     $ _history_list.pop()
                                     menu:
-                                        "And when I fall?":
-                                            m 1dub "I’ll be right there to show you how to fly."
+                                        "'And when I fall?'":
+                                            m 1dub "'I’ll be right there to show you how to fly.'"
                                             $ _history_list.pop()
                                             menu:
-                                                "And if I don’t want to fly anymore?":
-                                                    m 4hub "I’ll fall with you, however far down we go!"
+                                                "'And if I don’t want to fly anymore?'":
+                                                    m 4hub "'I’ll fall with you, however far down we go!'"
                                                     $ _history_list.pop()
                                                     menu:
-                                                        "You only exist in my head and in my heart! You always disappear when I open my eyes..":
-                                                            m 1tubsa "That's okay."
+                                                        "'You only exist in my head and in my heart! You always disappear when I open my eyes...'":
+                                                            m 1tubsa "'That's okay.'"
                                                             $ _history_list.pop()
                                                             menu:
-                                                                "Why?":
-                                                                    m 1fubsb "Because I know that your heart is safer than anywhere on earth I could be."
+                                                                "'Why?'":
+                                                                    m 1fubsb "'Because I know that your heart is safer than anywhere on Earth I could be.'"
                                                                     if mas_shouldKiss(chance=1):
                                                                         call monika_kissing_motion
 
         "I don't feel like it at the moment.":
-            m 2eud "Oh okay."
+            m 2eud "Oh, okay."
             m 2euu "Maybe another time then."
 
     return "kiss"

--- a/game/Submods/NSFW Submod/nsfw_topics.rpy
+++ b/game/Submods/NSFW Submod/nsfw_topics.rpy
@@ -15,7 +15,7 @@ label nsfw_monika_nsfwmodinstall:
     if renpy.seen_label('monika_nsfwmodinstall') and store.mas_getEVL_shown_count("nsfw_monika_nsfwmodinstall") < 1: # Fix for bad naming convention during early development
         return "derandom"
     m 1esc "Hey [mas_get_player_nickname()], I noticed something weird just now..."
-    m 1rsc "I'm kind of getting this feeling that... something's changed in this mod."
+    m 1rsc "I'm kind of getting this feeling that...something's changed in this mod."
     m 1etc "Do you know anything about this, [player]?"
     m 1hkb "Ahaha. It's not a bad feeling, don't get me wrong."
     m 1eta "It's just strange, you know?"
@@ -67,7 +67,7 @@ init 5 python:
             persistent.event_database,
             eventlabel="nsfw_monika_sexualpast",
             category=['sex'],
-            prompt="Sexual Past",
+            prompt="Sexual past",
             conditional="mas_canShowRisque()",
             action=EV_ACT_RANDOM,
         )
@@ -76,7 +76,7 @@ init 5 python:
 label nsfw_monika_sexualpast:
     if renpy.seen_label('monika_sexualpast') and store.mas_getEVL_shown_count("nsfw_monika_sexualpast") < 1: # Fix for bad naming convention during early development
         return
-    m 1rubsd "Umm... [player]?"
+    m 1rubsd "Umm...[player]?"
     m 1eubsc "I want to ask you something."
     m 1rubsd "It's about..."
     m 2hkbssdlb "Oh gosh, this is so embarrassing!"
@@ -84,15 +84,15 @@ label nsfw_monika_sexualpast:
     extend 2fkbfb "had sex before?{nw}"
     $ _history_list.pop()
     menu:
-        m "Have you... had sex before?{fast}"
+        m "Have you...had sex before?{fast}"
 
         "Yes.":
             m 2cubfw "R-Really?!{nw}"
             m 2hubfa "*ahem*...{w=1}{nw} "
             extend 1ekbfsdlb "Sorry, you just surprised me is all."
-            m 1rkbfsdlb "To be honest I should have seen this coming."
+            m 1rkbfsdlb "To be honest, I should have seen this coming."
             m 1ekblb "After getting to know you all this time, I can see why someone would fall for you."
-            m 1ekbstpd "And would... do those things with you."
+            m 1ekbstpd "And would...do those things with you."
             m 1dkbstpc "..."
             m 1hkbstpb "Ahaha! Sorry, I'm getting myself down over this."
             m 1ekbstdb "You're here with me now, that's all that matters."
@@ -109,18 +109,18 @@ label nsfw_monika_sexualpast:
     extend 3rkbsa " do it with me?{nw}"
     $ _history_list.pop()
     menu:
-        m "Would you... do it with me?{fast}"
+        m "Would you...do it with me?{fast}"
 
         "Yes.":
             m 1ekbsa "I'm so relieved!"
             m 1lkbsb "I was so nervous you wouldn't want to."
             m 1hkbssdlb "Although in retrospect it kind of wouldn't make sense if you didn't want to."
-            m 1hkblu "After all...{w=0.3} you installed this mod."
+            m 1hkblu "After all...{w=0.3}you installed this mod."
             if store.mas_isMoniLove():
                 m 1rsblu "And I'm sure you know this already..."
                 m 1rsblu "But...{w=0.5}{nw}"
-                extend 1lkbfb " I want to have sex with you, too."
-                m 3ekbfb "I-{w=0.4}I don't know what it feels like,{nw} "
+                extend 1lkbfb "I want to have sex with you, too."
+                m 3ekbfb "I-{w=0.4}I don't know what it feels like,{nw}"
                 extend 3rkbfb "and I'm so nervous just thinking about it, ahaha!"
                 m 4ekbfb "But I want my first time to be with you."
                 m 5ekbsu "I love you, and I trust you."
@@ -137,7 +137,7 @@ label nsfw_monika_sexualpast:
             m 1wkd "Oh."
             m 2rkd "I..."
             m 2dkc "I understand."
-            m 2dktpc "Thankyou for being honest with me."
+            m 2dktpc "Thank you for being honest with me."
             m 2dktpc "..."
             m 2fktpc "It's not something everyone is comfortable with, huh?"
             m 2rktpc "I know I shouldn't take this personally."
@@ -153,7 +153,7 @@ init 5 python:
             persistent.event_database,
             eventlabel="nsfw_monika_safesex",
             category=['sex'],
-            prompt="Safe Sex",
+            prompt="Safe sex",
             random=True,
             aff_range=(mas_aff.ENAMORED, None)
         )
@@ -176,23 +176,23 @@ label nsfw_monika_safesex:
         m 4eublb "It's a latex-rubber 'sheath' that you put around..."
         m 4wsbsd "..."
         m 2dfbsa "*ahem*"
-        m 2lkbfa "... You get the idea."
+        m 2lkbfa "...You get the idea."
         m 2lkbsb "It prevents any kind of fluid swapping during sex, which is supposed to prevent pregnancy and STDs."
     elif persistent.gender == "F":
         m 4eubla "I've read that there are condoms available for women, but they aren't as popular as the men's version."
-        m 4eub "The most popular form of contraception seemed to be 'The Pill'...{w=0.4}{nw}" 
+        m 4eub "The most popular form of contraception seems to be 'The Pill'...{w=0.4}{nw}" 
         extend 4hksdlb "which sounds kind of ominous if you ask me."
         m 4eub "It is exactly what it says it is, a pill you take to prevent pregnancy."
         m 3eub "There are different kinds of pills, too!"
-        m 3eua "There's a pill you're supposed to take every day at the same time the previous day."
+        m 3eua "There's a pill you're supposed to take every day at the same time as the previous day."
         m 2eub "And another pill that you can take in case of an emergency, respectfully called the 'morning after pill'."
-        m 4eublb "Despite it's name, it should actually be taken as soon as possible!"
+        m 4eublb "Despite its name, it should actually be taken as soon as possible!"
     else:
         m 4eubla "I've read that there are a whole bunch of different contraception methods, for both men and women."
         m 3eubla "Some are more popular than others, such as condoms for men, and oral contraceptives for women." #TODO - Add pose
     
     m 3lkblc "They are not exactly flawless though..."
-    m 4ekbld "There is still a chance that despite all the precautions, accidents can happen."
+    m 4ekbld "There is still a chance that accidents can happen in spite of all the precautions."
     m 4efbld "Especially with stupid contraceptive methods like the 'p{w=0.4}{nw}"
     extend 4efbfo "-pull-out' method!"
     m 2wfbfo "How is that even a form of contraception?!"
@@ -224,15 +224,15 @@ init 5 python:
 label nsfw_monika_fetish:
     if renpy.seen_label('monika_fetish') and store.mas_getEVL_shown_count("nsfw_monika_fetish") < 1: # Fix for bad naming convention during early development
         return
-    m 1esc "Hey [player]..."
+    m 1esc "Hey, [player]..."
     if store.mas_getEVL_shown_count("monika_panties") > 0:
         m 1esc "Do you remember when we spoke about guys with panty fetishes?"
         m 1rsc "Well, that got me thinking..."
     m 3esa "Do you...{w=0.5}{nw}"
-    m 3tsbla "Do you...{fast} have a fetish?"
+    m 3tsbla "Do you...{fast}have a fetish?"
     $ _history_list.pop()
     menu:
-        m "Do you... have a fetish?{fast}"
+        m "Do you...have a fetish?{fast}"
         "Yes":
             m 3wsbld "O-{w=0.2}Oh."
             if persistent._mas_pm_likes_panties:
@@ -264,7 +264,7 @@ label nsfw_monika_fetish:
     m 1ekbsa "I'm sure whatever you're into isn't dangerous at all, [player]."
     if store.mas_is18Over():
         m 3ekbsa "So, if you have a fantasy that isn't {i}too{\i} dangerous..."
-        m 5eubsa "I wouldn't mind being there to help you...{w=0.2} fulfill it."
+        m 5eubsa "I wouldn't mind being there to help you...{w=0.2}fulfill it."
         m 5hubsa "Ehehe~"
     return
 
@@ -285,21 +285,21 @@ label nsfw_monika_sexting:
         return
     m 3esa "Have you heard of sexting, [player]?"
     m 3rsbla "It seems to be pretty common amongst young couples to at least try sexting with their partners."
-    m 3esblb "If you don't know, It's basically texting but with a more...{w=0.4}{nw}"
-    extend 3rsbsb " sexual nature."
+    m 3esblb "If you don't know, it's basically texting but with a more...{w=0.4}{nw}"
+    extend 3rsbsb "sexual nature."
     m 4esbsa "Think of it like flirting, but with the limitations of doing it through your phone."
     m 4hkbsb "It might sound bizarre, but from what I've read it's a really helpful way for couples to stay close while they're away from one another."
     m 4hubsa "You won't always be able to spend intimate time with your partner, which can be frustrating."
     m 4hublb "So in a way, sexting helps keep relationships exciting!"
     m 4eublb "Not only that, but partners who have a 'long-distance relationship' with their significant other find benefits in sexting."
     m 2eublb "Couples will send 'sexts' to their partner, which can be with text..."
-    extend 2rkbsb " or photos..."
+    extend 2rkbsb "or photos..."
     m 2rkbsa "And will imitate the act of sex through their phone."
     m 2hkblsdlb "Ahaha! It's not as silly as it sounds."
     m 2rkbsa "Partners will more often than not m-{w=0.4}masturbate while sexting."
     m 2rkbsb "They'll tell their partner what they want to do with them..."
-    extend 2lkbsb " Or what they want done {i}to{/i} them."
-    m 3lkbsb "All the meanwhile sending photos of what they're doing with themselves while they talk."
+    extend 2lkbsb "Or what they want done {i}to{/i} them."
+    m 3lkbsb "...while sending photos of what they're doing with themselves while they talk."
     if store.mas_canShowRisque():
         m 2dubsu "..."
         m 2gubsu "Say, [player]..."
@@ -327,7 +327,7 @@ init 5 python:
             persistent.event_database,
             eventlabel="nsfw_monika_gettingnude",
             category=['sex'],
-            prompt="Getting Nude",
+            prompt="Getting nude",
             random=True,
             aff_range=(mas_aff.LOVE, None)
         )
@@ -336,21 +336,21 @@ init 5 python:
 label nsfw_monika_gettingnude:
     if renpy.seen_label('monika_gettingnude') and store.mas_getEVL_shown_count("nsfw_monika_gettingnude") < 1: # Fix for bad naming convention during early development
         return
-    m 1eua "Hey [player], have you ever just... not worn clothes?"
+    m 1eua "Hey [player], have you ever just...not worn clothes?"
     m 1hksdlb "I don't mean, like, for a shower or anything."
     m 1husdla "Just in general while you're at home...{w=0.5}{nw}"
     extend 1lusdla "alone preferably."
     m 1eua "There are a good amount of people that actually sleep naked, if you'll believe it."
-    m 3eua "For most people this would be a good place to start without feeling embarrased."
+    m 3eua "For most people, this would be a good place to start without feeling embarrased."
     m 3eub "Apparently it helps you get better sleep at night because of how much quicker your body temperature drops."
     m 3rub "Of course, sleeping naked will mean you have to clean your sheets more often."
     m 3hksdlb "Humans are very sweaty, ahaha!"
     m 3eub "Being naked also helps our body absorb more vitamin D during the day."
-    m 4eub "The reason for this is because skin is effectively a giant organ that absorbs the rays from the sun and increases our vitamin D levels."
+    m 4eub "The reason for this is that skin is effectively a giant organ that absorbs the rays from the sun and increases our vitamin D levels."
     m 4eua "And having a greater vitamin D level has shown to assist your immune system fight off viruses, among other health benefits."
-    m 3hksdlb "I'm not trying to say we all need to get naked and make it a new social norm, that would be silly! Ahaha!"
-    m 3eua "But if you have the house to yourself one day, why not strip down and try it for an hour to see how you feel."
-    m 3rusdld "Though be sure you know when the rest of your household is getting back, because that might be a {i}tad{/i} awkward."
+    m 3hksdlb "I'm not trying to say we all need to get naked and make it a new social norm; that would be silly! Ahaha!"
+    m 3eua "But if you have the house to yourself one day, why not strip down and try it for an hour to see how you feel?"
+    m 3rusdld "Though be sure you know when the rest of your household is getting back, because that might be a {i}bit{/i} awkward."
     m 3eua "If that's too much, even just going down to your underwear gets the job done..."
     m 2dkd "{i}*sigh*{/i}"
     m 2gkc "Of course, there is always the fact that not everyone is comfortable being naked."
@@ -362,7 +362,7 @@ label nsfw_monika_gettingnude:
         m 2rkbla "..."
         m 2rkblb "Hey, [player]..."
         m 2ekblb "Do you remember last time when I asked you if it was okay to be undressed around you?"
-        m 3ekblb "Well, I recently tried taking off... everything..."
+        m 3ekblb "Well, I recently tried taking off...everything..."
         m 3ekbla "And I really liked it."
         m 3eubla "I don't know if you've ever tried it before, [player]. But I thought the feeling was amazing."
         m 3hublsdlb "Ahaha! Maybe that feeling wouldn't be so great if someone saw you though..."
@@ -375,7 +375,7 @@ label nsfw_monika_gettingnude:
             m "Can I be n-naked while you're here?{fast}"
             
             "Of course you can.":
-                m 1ekbfa "Thankyou, [player]."
+                m 1ekbfa "Thank you, [player]."
                 m 1dkbfa "It puts my mind at ease that you don't mind me doing this."
                 m 2ekbsa "I know not everyone is comfortable being around someone naked."
                 m 2dsbsa "Give me one second, I'm just going to get out of these clothes."
@@ -385,9 +385,9 @@ label nsfw_monika_gettingnude:
                 m 4hubsb "Ah~! That's much better."
                 m 6tubsb "Ehehe~ Do you like what you see, [mas_get_player_nickname()]?"
                 m 1gkbfu "..."
-                m 1hkbfsdlb "Ahaha! Sorry, this is still kind of embarrasing for me."
+                m 1hkbfsdlb "Ahaha! Sorry, this is still kind of embarrassing for me."
                 m 1mkbfsdlb "It might take a little getting used to..."
-                m 1ekbfb "Thankyou again, [player]."
+                m 1ekbfb "Thank you again, [player]."
                 
             "Please don't...":
                 m 3wkbld "Oh..."
@@ -400,7 +400,7 @@ label nsfw_monika_gettingnude:
 
     elif mas_nsfw.canShow_underwear():
         m 2rkbla "..."
-        m 2rkblb "Speaking of, [player]..."
+        m 2rkblb "Speaking of which, [player]..."
         m 2ekblb "I've recently tried walking around in my underwear by myself while you were gone,{nw}"
         extend 2eubla " and I thought it felt really liberating."
         m 1rublc "But in saying that I don't want you to feel uncomfortable, so..."
@@ -422,15 +422,16 @@ label nsfw_monika_gettingnude:
 
                 m 2ekbsa "So, [player]..."
                 m 2ekbsa "What do you think?"
-                m 2rkbsa "I'm... not used to this..."
+                m 2rkbsa "I'm...not used to this..."
                 if mas_hasUnlockedClothesWithExprop("lingerie"):
                     m 2ekbsa "I know you've seen me in lingerie before, which is arguably more...{w=0.3}{nw}"
-                    extend 2rkbfa " sexual."
+                    extend 2rkbfa "sexual."
                     m 2ekbsb "But this feels way different."
                 m 2hkbssdlb "Ahaha! It might take me a while to get used to you seeing me like this..."
-                m 2ekbla "But I'm still glad you don't mind me dressed this way."
+                m 2ekbla "But I'm still glad you don't mind me being dressed this way."
                 m 2dkbla "Being able to dress freely around you makes me feel really happy."
                 m 1ekbsa "I love you, [player]."
+                return "love"
 
             "I'd rather you didn't...":
                 m 2wkbld "Oh..."
@@ -459,7 +460,7 @@ label nsfw_monika_gettingnude:
         m 2dka "..."
         m 1eua "Alright, I've decided."
         m 1eublb "I'm going to give it a try."
-        m 1wubld "... {w=0.4}{nw}"
+        m 1wubld "...{w=0.4}{nw}"
         extend 1wubso "N-{w=0.2}Not right now though!"
         m 1hubssdlb "I mean like, later when you're not here!"
         m 1rubssdlb "Ahaha! It would be too embarrasing if you saw me in my underwear, let alone when I'm naked."
@@ -484,32 +485,32 @@ label nsfw_monika_shaving:
         return
     m 1esc "Hey [player]..."
     m 3eub "I want to ask you something."
-    m 3lusdlb "It's about my body.. "
-    extend 2lusdlb "Do you like it to be shaved down there?.."
+    m 3lusdlb "It's about my body..."
+    extend 2lusdlb "Do you like it to be shaved down there...?"
     $ _history_list.pop()
     menu:
-        m "Do you like it to be shaved down there?..{fast}"
+        m "Do you like it to be shaved down there...?{fast}"
 
         "Yes.":
             m 1hua "That's to be expected."
-            m 1eua "Most partners maintain themselves down there in one way or another."
+            m 1eua "Many partners maintain themselves down there in one way or another."
             m 3wuo "Most girls certainly do!"
             m 5tuu "We just want to make sure we're ready for you~"
             m 5tuu "I certainly will."
-            m 5hub "Ahaha!.."
+            m 5hub "Ahaha!"
 
-        "I don't mind.":
+        "I don't mind if you don't":
             m 1wuo "Really?!"
             m 5hub "That's surprising!"
             m 5dub "Most partners prefer their loved ones to be shaved."
             m 3eua "It feels nice to know your partner likes the way you look no matter what."
             m 3fub "I'll have to stop shaving so much."
             m 1mub "It'll take a lot less time to shower now too!"
-            m 5hub "Ahaha!.."
+            m 5hub "Ahaha!"
 
     m 1eua "I think you know how I feel."
-    m 1wub "However you present yourself.."
-    m 1hub "Shaven or natural.."
+    m 1wub "However you present yourself..."
+    m 1hub "Shaven or natural..."
     m 1nub "I'll always love you!"
 
     return "love"
@@ -521,7 +522,7 @@ init 5 python:
             persistent.event_database,
             eventlabel="nsfw_monika_judging_sexual_desires",
             category=['sex'],
-            prompt="Judging Sexual Desires",
+            prompt="Judging sexual desires",
             random=True,
             aff_range=(mas_aff.ENAMORED, None)
         )
@@ -530,26 +531,25 @@ init 5 python:
 label nsfw_monika_judging_sexual_desires:
     m 2efc "I don't understand why so many people have problems with fetishes!"
     m 3efd "People take it too seriously."
-    m 3efd "With sexuality being a taboo on a good day-"
+    m 3efd "With sexuality being a taboo on a good day..."
     m 4efd "Deviations are always observed with judgemental eyes."
     m 1eud "They take that small, personal aspect of one's life and put a spotlight on it."
-    m 1eud "and under that spotlight, sexuality casts an ugly shadow.."
-    m 1tud "and society frowns upon it.."
+    m 1eud "And under that spotlight, sexuality casts an ugly shadow..."
+    m 1tud "and society frowns upon it..."
     m 2hsc "..."
     m 2fuu "But there are those who understand that it is a wonderful aspect of the human experience."
-    m 2hubsa "Wonderful.."
-    m 2hubsa "Exciting.."
-    m 5fubsa "Intimate.."
+    m 2hubsa "Wonderful..."
+    m 2hubsa "Exciting..."
+    m 5fubsa "Intimate..."
     m 5dubfa "..."
     m 2eubfd "[player]..."
     m 2eubfd "Please share your desires with me."
     m 3eubfa "Honest communication is the most important thing in a relationship after all!"
     m 3subfb "I don't judge! No matter how out there it is!"
-    m 5gubfa "I should know after all.."
+    m 5gubfa "I should know, after all..."
     m 3eubfb "We are all a bit pervy, in our own special ways!"
-    m 3eubfb "You might be thinking.."
-    m 6tfbfp "No! I most certainly am not!"
-    m 5tubfu "Well.."
+    m 3eubfb "You might be thinking, 'No! I most certainly am not!'"
+    m 5tubfu "Well..."
     m 5tubfu "Give it some time~"
 
     return
@@ -560,7 +560,7 @@ init 5 python:
             persistent.event_database,
             eventlabel="nsfw_player_sextingsession",
             category=['sex'],
-            prompt="Do you wanna sext?",
+            prompt="Do you want to sext?",
             pool=True,
             aff_range=(mas_aff.LOVE, None)
         )


### PR DESCRIPTION
There are slight adjustments to make the style of speech more consistent with the grammar rules and patterns observed in MAS `script-topics.rpy`.

notes:
- MAS isn't 100% consistent with punctuation but there is a general pattern... If two sentences on a line are separated by an ellipsis, there is usually a whitespace between it and the second sentence.
- Ellipses that indicate a pause...in the middle of a sentence usually are not followed by a space.
- Changed instances of two dot ellipsis (..) to three dot ellipsis (...)
- _Thankyou_, _abit_, _alot_, etc. aren't proper English; they should be written _thank you_, _a bit_, _a lot_.
- Most topic titles have only the first word capitalized (barring proper nouns).
- Some sentences have two halves that work as sentences on their own; independent clauses like these are separated with a semicolon.