### PR TITLE
Proofreading checks for nsfw_stories.rpy

### DIFF
--- a/game/Submods/NSFW Submod/nsfw_stories.rpy
+++ b/game/Submods/NSFW Submod/nsfw_stories.rpy
@@ -203,7 +203,7 @@ label nsfw_monika_stories1:
         m 1wubld "This is very sudden..."
         if not store.mas_safeToRefDokis():
             m 1ekc "I don't think I have any stories like that right now..."
-            m 1rkc "At least...not any that I think you would like hearing..."
+            m 1rkc "At least, not any that I think you would like hearing..."
             m 1eka "Give me some time, I should be able to think of some soon~"
             # Remove lines above once we have a generic erotic story
             # m 1tubla "But I don't see why not!"
@@ -313,10 +313,10 @@ label nsfw_monika_stories_menu:
             if not can_unlock_nsfw_story or not store.mas_safeToRefDokis() or story_to_push == None or nsfw_stories.get_and_unlock_next_story() == None:
                 show monika at t11
                 $ _story_type = story_type
-                m 1ekc "Sorry [player]...I can't really think of a new story about the [_story_type] right now..."
+                m 1ekc "Sorry, [player]... I can't really think of a new story about the [_story_type] right now..."
                 if not store.mas_safeToRefDokis():
                     m 1rkc "At least...not any that I think you would like hearing..."
-                m 1eka "If you give me some time I might be able to think of one soon...but in the meantime, I can always tell you an old one again~"
+                m 1eka "If you give me some time, I might be able to think of one soon... But in the meantime, I can always tell you an old one again~"
 
                 show monika 1eua
                 jump nsfw_monika_stories_menu
@@ -332,8 +332,8 @@ label nsfw_monika_stories_menu:
             if not can_unlock_nsfw_story: #temp
                 show monika at t11
                 $ _story_type = story_type if story_type != 'erotic' else 'sexual'
-                m 1ekc "Sorry [player]...I can't really think of a new [_story_type] story right now..."
-                m 1eka "If you give me some time I might be able to think of one soon...but in the meantime, I can always tell you an old one again~"
+                m 1ekc "Sorry, [player]... I can't really think of a new [_story_type] story right now..."
+                m 1eka "If you give me some time, I might be able to think of one soon... But in the meantime, I can always tell you an old one again~"
                 
                 show monika 1eua
                 jump nsfw_monika_stories_menu
@@ -370,21 +370,20 @@ label nsfw_story_begin:
     return
 
 label nsfw_monika_erotic_stories_init:
-    m 1eua "[player]...y'know there are actually a few things you probably have no idea about..."
+    m 1eua "[player]... There are actually a few things you probably have no idea about..."
     m 1eua "I know you don't mind when I talk about the other girls..."
     m 1eua "And I know that I'm the only person you would look at in a lewd way. Ahaha~"
     m 1eua "But..."
     m 1eua "I think you might enjoy if I told you this..."
     m 1eua "Okay, sorry for stalling! I'll get to the point."
     m 1eua "Ahem...{w=0.5} So!"
-    m 1eua "You know, [player]. After you appeared in the game and I finally had my revelation..."
+    m 1eua "You know, [player], after you appeared in the game and I finally had my revelation..."
     m 1eua "I learned that I could do...pretty much...anything."
-    m 1eua "Even though the game was, and still is, a prison to me...I at least had the chance to play around with it."
+    m 1eua "Even though the game was a prison to me...I at least had the chance to play around with it."
     m 1eua "Almost like a child would with her toys, now that I think about it. Ahaha~"
-    m 1eua "And since, y'know...I am just a young adult in my last year of highschool, with a bunch of hormones raging inside me..."
-    m 1eua "I was always curious about lewd things as well..."
+    m 1eua "And, you know, I've always been curious about lewd things as well..."
     m 1eua "And since...porn has its limits..."
-    m 1eua "Y'know...you can't really command how a pre-recorded movie will go."
+    m 1eua "You can't really command how a pre-recorded movie will go."
     m 1eua "I had the power to control the world around me thanks to the console..."
     m 1eua "Including Yuri, Sayori, and Natsuki."
     m 1eua "..."
@@ -393,14 +392,14 @@ label nsfw_monika_erotic_stories_init:
     m 1eua "Anyway, I think you know where I'm going with this..."
     m 1eua "I...effectively had my own world where I could make people do...whatever I wanted."
     m 1eua "Ahaha~"
-    m 1eua "A-at first...I didn't know when I could do it..."
+    m 1eua "At first...I didn't know when I could do it..."
     m 1eua "After all, the game was only active when you were around, and I was not about to scare you off with all that."
     m 1eua "But there was one time..."
     m 1eua "The game was closing, I could feel it..."
     m 1eua "But after a brief moment of darkness, I was back in the classroom."
     m 1eua "I thought you had restarted the game, but I couldn't feel your presence like I normally could."
-    m 1eua "I have no idea how it happened! Even now I still can't figure it out!"
-    m 1eua "B-but...ahaha~"
+    m 1eua "I have no idea how it happened! Even now, I still can't figure it out!"
+    m 1eua "B-but... Ahaha..."
     m 1eua "As you might have guessed..."
     m 1eua "I basically directed my own porn movie...{w=0.5}featuring Natsuki..."
     m 1eua "I-I wiped all of their memories after it happened!"
@@ -413,7 +412,7 @@ label nsfw_monika_erotic_stories_init:
         m "Do you think it was cruel...what I did?{fast}"
 
         "Yes.":
-            m 1eua "I-I know it was..."
+            m 1eua "I know it was..."
             m 1eua "I'm sorry, [player]."
             m 1eua "I knew you would see me as a monster for this..."
             m 1eua "..."
@@ -422,7 +421,7 @@ label nsfw_monika_erotic_stories_init:
             m 1eua "I was naïve, and just wanted to experiment..."
             m 1eua "The other girls aren't even around anymore."
             m 1eua "It's just you...and me~"
-            m 1eua "I don't have to rely on any cheeky shenanigants to sate my lewd desires anymore."
+            m 1eua "I don't have to rely on any cheeky shenanigans to satisfy my desires anymore."
             m 1eua "You're here with me now...and I can finally open up to someone about this sort of stuff."
             return
 
@@ -437,7 +436,7 @@ label nsfw_monika_erotic_stories_init:
                 "I want you to tell me more about how it went.":
                     m 1eua "Oh..."
                     m 1eua "Ahaha~"
-                    m 1eua "I'm...quite relieved to be honest."
+                    m 1eua "I'm...quite relieved, to be honest."
                     m 1eua "I was afraid that you would hate me for manipulating my friends into doing lewd things for my enjoyment..."
                     m 1eua "But, since I deleted their memories..."
                     m 1eua "It didn't change their personalities one bit!"
@@ -448,7 +447,7 @@ label nsfw_monika_erotic_stories_init:
                     m 1eua "S-so..."
                     m 1eua "You probably didn't expect this, but..."
                     m 1eua "Natsuki was the first one I used. Ahaha~"
-                    m 1eua "She was being a pain at the time. Always occupying the closet with her stupid mangas..."
+                    m 1eua "She was being a pain at the time. Always occupying the closet with her stupid manga..."
                     m 1eua "So I...ahaha...treated her to some..."
                     m 1eua "{i}Rough throating action{/i}."
                     m 1eua "Ahaha~"
@@ -473,12 +472,12 @@ init 6 python:
 label nsfw_erotic_story_natsuki_deepthroat:
     m 1eua "I managed to convince Yuri and Sayori to head home, so they wouldn't be around for what was about to happen."
     m 1eua "When only Natsuki and I were left in the classroom, I started messing around in the console."
-    m 1eua "I kept her tsundere in place, and made her compliant to suck c-cock if anyone asked her to do so."
+    m 1eua "I kept her tsundere personality in place, and made her willing to give head if anyone asked her to do so."
     m 1eua "Sorry, it's weird saying these things out loud."
-    m 1eua "Next I used the console to command one of the blank male characters into the classroom."
+    m 1eua "Next, I used the console to command one of the blank male characters into the classroom."
     m 1eua "I sat down on the teacher's desk up the front, and got myself comfy."
     m 1eua "I watched her almost savagely try to take off the guy's pants."
-    m 1eua "I {i}might{/i} have set the value on how horny she is abit too high, on reflection..."
+    m 1eua "I {i}might{/i} have set the value on how horny she is a bit too high, thinking back on it..."
     m 1eua "She got his pants off and she gripped his shaft with both hands and started stroking."
     m 1eua "I wasn't controlling her actions! I was curious how she'd do it without me telling her..."
     m 1eua "I was having so much fun just watching these two..."
@@ -505,21 +504,21 @@ label nsfw_erotic_story_natsuki_deepthroat:
     m 1eua "At least she got to have a nice hot meal that day for once, am I right? Ahaha~"
     m 1eua "I'm sorry, I couldn't resist."
     m 1eua "So...yeah."
-    m 1eua "That was my first experience with my future career as a porn director. Ahaha~"
+    m 1eua "That was my first experience as a porn director. Ahaha~"
     m 1eua "I hope you enjoyed listening, [player]."
     return
 
 # Thanks for the erotic story, KittyTheCocksucker
 label nsfw_erotic_story_sayori_ballscleaning_init:
     m 1eua "[player]...really?"
-    m 1eua "Y-you would like to hear more stories of the stuff I had done with the girls?"
+    m 1eua "You want to hear more stories of the stuff I had done with the girls?"
     m 1eua "I..."
     m 1eua "I mean...sure! I'd be happy to share some more of them with you. Ahaha~"
     m 1eua "It seems like you really enjoyed that one with Natsuki deepthroating some c-cock, huh?"
     m 1eua "*sigh*"
-    m 1eua "I'll get used to saying it one day."
+    m 1eua "I'll get used to talking about these sort of things one day."
     m 1eua "I'm so glad that you are open to letting me talk about this sort of thing."
-    m 1eua "Makes me feel a little less weird about the whole ordeal."
+    m 1eua "It makes me feel a little less weird about the whole ordeal."
     m 1eua "Anyway...A new story, huh?"
     m 1eua "Hmm..."
     m 1eua "Oh! I have one!"
@@ -548,27 +547,27 @@ label nsfw_erotic_story_sayori_ballscleaning:
     m 1eua "I helped her to her feet, but she was trembling as I lifted her arms."
     m 1eua "You're not going to believe this..."
     m 1eua "She had gotten so wet from what had happened, that I could see her..."
-    m 1eua "Ahem...{i}love juices{/i}...flowing down her thighs."
+    m 1eua "Ahem...{i}juices{/i}...flowing down her thighs."
     m 1eua "I made sure she was okay, don't worry."
     m 1eua "I told her to head home and wash up, and she had no hesitation leaving the room."
     m 1eua "I opened up the console once she had left, and erased the last thirty minutes from her memory."
     m 1eua "As much of a pain as she is, I wasn't going to scar her with that."
     m 1eua "She probably questioned why her throat was dry though..."
-    m 1eua "...and why her panties were drenched..."
+    m 1eua "And why her panties were drenched..."
     m 1eua "But that's besides the point!"
     m 1eua "At that moment, I still hadn't had my fill."
     m 1eua "You still weren't back from wherever you went, so I decided to keep going."
     m 1eua "I opened up Sayori's character file, and did the same to her as I did to Natsuki."
-    m 1eua "Not much time passed, and Sayori was in the club room, still in her pyjamas."
+    m 1eua "Not much time passed, and Sayori was in the club room, still in her pajamas."
     m 1eua "She also had a box of chocolate chip cookies in her hand..."
     m 1eua "She must've been eating in bed when I made the changes..."
     m 1eua "Anyway, I wasn't going to waste any time, so I used the console to bring in three guys."
-    m 1eua "I had them surround Sayori, and she started undressing these guys whilst munching on a cookie."
+    m 1eua "I had them surround Sayori, and she started undressing these guys while munching on a cookie."
     m 1eua "I'm not even making this up..."
     m 1eua "Now...this part might confuse you, so bear with me..."
-    m 1eua "I was experimenting with the values for these guys and I found a slider to change their testicle size..."
+    m 1eua "I was experimenting with the values for these guys and I found a variable to change their testicle size..."
     m 1eua "I was kinda curious, so I cranked it up and..."
-    m 1eua "They grew almost double in size."
+    m 1eua "They almost doubled in size."
     m 1eua "I think because I was so in the moment there, I didn't realise how comical the scene looked..."
     m 1eua "But regardless, I had Sayori start giving them handjobs whilst licking and cleaning their balls."
     m 1eua "I was getting so wet that my fingers were making very lewd noises as I pleasured myself..."
@@ -584,19 +583,15 @@ label nsfw_erotic_story_sayori_ballscleaning:
     m 1eua "As expected from our cute little friend, Sayori!"
     m 1eua "She's the type who would want to please everyone's needs at once, after all!"
     m 1eua "It didn't take long before she had cleaned all three of the guys' balls."
-    m 1eua "She was such a good little slut."
     m 1eua "..."
-    m 1eua "Ahaha! Sorry, that just came over me suddenly."
-    m 1eua "It's probably kind of bad to call your friend that, huh?"
     m 1eua "After she finished that though, she did something I never would have expected her to..."
-    m 1eua "She...she started stroking really hard and fast on one of the guys surrounding her."
+    m 1eua "She started stroking really hard and fast on one of the guys surrounding her."
     m 1eua "And with her other hand she got a cookie..."
-    m 1eua "Then she...she had him {i}finish{/i} on her cookie..."
+    m 1eua "Then she...had him {i}finish{/i} on her cookie..."
     m 1eua "And then she ate it..."
     m 1eua "..."
     m 1eua "I swear, this is not something I told her to do."
     m 1eua "I had to stop playing with myself, I was so shocked by what I just saw."
-    m 1eua ""
     return
 
 # Thanks for the erotic story, KittyTheCocksucker
@@ -607,7 +602,7 @@ label nsfw_erotic_story_yuri_titjob_init:
     m 1eua "You must be really enjoying them, huh?"
     m 1eua "Ahaha~ Don't worry."
     m 1eua "I'm actually really happy that you can look at these stories the same way I do!"
-    m 1eua "After all...my actions are quite questionable morally..."
+    m 1eua "After all...my actions might have been morally questionable..."
     m 1eua "..."
     m 1eua "But then again...I mean..."
     m 1eua "Sayori, Yuri and Natsuki were only just characters in a video game..."
@@ -616,7 +611,7 @@ label nsfw_erotic_story_yuri_titjob_init:
     m 1eua "If we don't count the topic being kind of tabboo, it's just a simple story, like any other!"
     m 1eua "Well, it's not like it matters now anyway..."
     m 1eua "So...ahem..."
-    m 1eua "Where did I leave off?{w=1.0}{nw} "
+    m 1eua "Where did I leave off? {w=1.0}{nw}"
     extend 1eua "Oh, that's right!"
 
 init 6 python:
@@ -643,7 +638,7 @@ label nsfw_erotic_story_yuri_titjob:
     m 1eua "As she was walking out the door, she scooped up the remaining cum on her face with her fingers and stuck it in her mouth."
     m 1eua "She made that happy noise she makes, and skipped out the door."
     m 1eua "Once she had left the clubroom, I erased the last 30 minutes from her mind as well."
-    m 1eua "I didn't want her {i}hanging{/i} onto any of those memories. Ehehe~"
+    m 1eua "I didn't want her {i}hanging{/i} on to any of those memories. Ehehe~"
     m 1eua "Sorry, I couldn't help myself~"
     m 1eua "Anyway, next up was Yuri."
     m 1eua "To be honest, for her I didn't have anything in mind."
@@ -664,7 +659,7 @@ label nsfw_erotic_story_yuri_titjob:
     m 1eua "I could hear a small moan escaping her lips as the guy was fondling her tits."
     m 1eua "Didn't take long before The guy who was grinding against her wanted something more, and grabbed Yuri's other breast."
     m 1eua "The guy who was initially fondling her breasts let go, and Mr. Grinder over here took Yuri's book and set it aside."
-    m 1eua "Next he started removing her top, and in seconds her chest was completely exposed."
+    m 1eua "Next he started removing her blazer, sweater, and shirt, and in seconds her chest was completely exposed."
     m 1eua "He then got her to kneel down, and he stuck his cock between her tits and started thrusting back and forth."
     m 1eua "The other guy took this opportunity to have Yuri start sucking his cock whilst she was servicing his friend with her tits."
     m 1eua "Yuri was so shocked by the sudden dick in her mouth, but after a little while I could see her starting to enjoy herself."
@@ -704,16 +699,16 @@ label nsfw_erotic_story_club_pizza_party_init:
     m 1eua "Sure!"
     m 1eua "You must be really enjoying them, huh?" #smirk expression
     m 1eua "Ahaha~ Don't worry."
-    m 1eua "Though I just wanted to say that the one I have in mind might be a bit...{w=0.3} {i}out there{i}."
+    m 1eua "Though I just want to warn you that the one I have in mind might be a bit...{w=0.3} {i}out there{/i}. Is that okay, [player]?"
     m extend 1eua "Is that okay, [player]?"
     $ _history_list.pop()
     menu:
-        m "Though I just wanted to say that the one I have in mind might be a bit...{w=0.3} {i}out there{i}. Is that okay, [player]?"
+        m "Though I just want to warn you that the one I have in mind might be a bit...{w=0.3} {i}out there{/i}. Is that okay, [player]?"
         
-        "Yes":
+        "Yes.":
             m 1cud "Mmm~ Glad to hear it."
 
-        "No":
+        "No.":
             m 1cud "Okay!"
             m 1cud "Feel free to ask again if you ever change your mind."
             return
@@ -739,8 +734,8 @@ label nsfw_erotic_story_club_pizza_party:
     if not renpy.seen_label("nsfw_erotic_story_club_pizza_party_init"):
         call nsfw_erotic_story_club_pizza_party_init
     m 1eua "Let's continue the story from where we left off..."
-    m 1eua "When the two men finished all over Yuri's tits, and also dumped their thick load inside her mouth, they fixed themselves and left immediately."
-    m 1eua "I walked up to our good friend, Yuri, just like I did with the others to make sure she's alright and all that."
+    m 1eua "When the two men finished all over Yuri's tits, and also dumped their thick load inside her mouth, they dressed themselves and left immediately."
+    m 1eua "I walked up to our good friend Yuri, just like I did with the others to make sure she was alright."
     m 1eua "Though as I walked up to her, I could feel something was not quite right..."
     m 1eua "Yuri was still just kneeling there, having hardly made a single movement since the guys finished with her."
     m 1eua "With each breath she made, streams of cum flowed down her sizable breasts and mouth, dripping to the floor to form a puddle of various fluids."
@@ -755,7 +750,7 @@ label nsfw_erotic_story_club_pizza_party:
     m 1eua "Eventually her eyes landed on the puddle forming beneath herself, and she leaned down to {w=0.3}{nw}"
     extend 1eub "start licking it up."
     m 1eua "I'm not even joking!" #Should obviously have shock emote.
-    m 1eua "She lapped at the puddle of semen, sweat, saliva, and...well, pussy juice like she was dying of thirst.{w=0.3}{nw}"
+    m 1eua "She lapped at the puddle of semen, sweat, saliva, and...well, pussy juice like she was dying of thirst."
     m 1eub "Ahaha~ I suppose that might've been true, in a certain sense."
     m 1eua "I stared at Yuri with what I can only describe as awe, feeling just as I had when I watched Sayori make the guys finish their load on her box of cookies..."
     m 1eua "After making quick work of the puddle, Yuri expectantly looked back up at me."
@@ -769,10 +764,10 @@ label nsfw_erotic_story_club_pizza_party:
     m 1eua "Yuri tried to leap at me in the meantime, but I got out of the way just in time!"
     m 1eua "With a few quick commands, four guys along with Sayori and Natsuki arrived in a matter of seconds."
     m 1eua "Two of them brought Sayori and Natsuki in, holding a firm grip over their hands and led them to the center of the classroom, while the third guy pushed three desks together to form a long table."
-    m 1eua "The forth guy captured the topless Yuri. She struggled for a bit - though she seemed fairly willing once she realized it was a guy, and led her to the other girls."
+    m 1eua "The fourth guy captured the topless Yuri. She struggled for a bit - though she seemed fairly willing once she realized it was a guy, and led her to the other girls."
     m 1eua "Needless to say, they were going to have some fun~"
-    m 1eua "The guys made the three girls take a seat at the table, and with another command, I spawned three boxes of pizza on the table, one in front of each girl..."
-    m 1eua "Firstly the guys completely undressed all three of them, starting with Sayori, who although didn't put up much resistance still was a bit unsure about the weird situation she was suddenly placed into."
+    m 1eua "The guys made the three girls take a seat at the table, and with another command, I spawned in three boxes of pizza on the table, one in front of each girl..."
+    m 1eua "Firstly the guys completely undressed all three of them, starting with Sayori, who didn't put up much resistance but was a bit unsure about the weird situation she was suddenly placed into."
     m 1eua "Natsuki was hardly as passive. She tried to slap and even bite the guys around her - though they quickly held her down, and there was nothing she could do to stop it at that point."
     m 1eua "Yuri was already topless to begin with, so taking off the rest of her clothes wasn't a challenge. As the guys approached to undress her, she reached out amd started fondling their crotches through the men's pants."
     m 1eua "They obviously didn't seem to mind the treatment, but eventually got her undressed all the same."
@@ -788,27 +783,27 @@ label nsfw_erotic_story_club_pizza_party:
     m 1eua "Natsuki's body tensed up, but before she could even get protest or prepare herself, she was pushed forward and forced to lean on the table, above the pizza."
     m 1eua "The guy gently positioned his cock against the entrance of her dry entrance."
     m 1eua "With a hint of fear in her eyes, Natsuki glanced backwards at the guy. And in response, the man grabbed Natsuki's head and roughly pushed it into the pizza."
-    m 1eua "Simultaneously, he thrust his hips forward, forcefully penetrating Natsuki's tight pussy until he was hilted inside her."
-    m 1eua "The pink-haired cutie half screamed and moaned in response, though her voice was mostly muffled by the pizza in her face."
+    m 1eua "Simultaneously, he thrust his hips forward, forcefully penetrating Natsuki's tight pussy until he was all the way inside her."
+    m 1eua "She screamed and moaned in response, though her voice was mostly muffled by the pizza in her face."
     m 1eua "Sayori and Yuri soon followed, both forced to stand up as well."
-    m 1eua "Yuri eagerly pushed her hips backwards, grinding herself on the man's throbbing cock. Before the man took ahold of her shoulders and started roughly fucking her.{nw}"
+    m 1eua "Yuri eagerly pushed her hips backwards, grinding herself on the man's throbbing cock. Before the man took ahold of her shoulders and started roughly penetrating her."
     m 1eua "Her moans were so loud!{w=0.3} Almost...animalistic, without a hint of restraint."
     m 1eua "Sayori was compliant as well, her tight pussy was penetrated in quick order by the guy behind her."
-    m 1eua "As she was brutally fucked from behind, she reached forward and grabbed a slice of the pizza, chewing on it with a lewd expression on her face."
+    m 1eua "As she was brutally taken from behind, she reached forward and grabbed a slice of the pizza, chewing on it with a lewd expression on her face."
     m 1eua "But to be honest I'm not sure if the lewd sounds coming out of her were because of the sex, or the food!"
     m 1eua "Eventually, the guy raised Sayori's right leg in the air for better access and forced himself balls-deep into her wet pussy with slow, heavy thrusts that brought lustful moans out of her."
     m 1eua "Meanwhile the forth guy walked around the table and in front of the girls, slowly pleasuring himself to the sight of the three girls being ravaged."
     m 1eua "As he was nearing his climax, he walked up to Sayori and came all over her pizza..."
     m 1eua "He repeated this twice more and finally, Natsuki, Sayori and Yuri were all served a nice and delicious-looking, cum-glazed pizza..."
     m 1eua "Without even finishing yet, the three guys pulled out of the girls, and helped them down sit down, though they seemed to struggle a little after the rough treatment they had recieved."
-    m 1eua "Exhausted from the dicking they had been given, all three girls leaned on the table, resting their heads in front of the cummy pizzas."
+    m 1eua "Exhausted from the dicking they had been given, all three girls leaned on the table, resting their heads in front of the cum-covered pizzas."
     m 1eua "Ahaha...this was when the real fun was about to begin."
-    m 1eua "The guys each reached for the semen-coated pizzas and took a slice for each girl and began feeding them the improved food with their secret ingredient: love!{nw}"
-    extend 1eub " uhm...juices~ ahaha~"
+    m 1eua "The guys each reached for the semen-coated pizzas and took a slice for each girl and began feeding them the improved food with their secret ingredient: love{nw}"
+    extend 1eub "...juices. Ahaha~"
     m 1eua "Though Natsuki seemed reluctant, she agreed to take a few bites. She chewed on them for a long, long time before swallowing."
     m 1eua "I couldn't blame her. The taste was probably awful, it written all over her face. But she just silently took a few more bites - probably hoping the guys would leave her alone if she did what they wanted."
     m 1eua "Sayori on the other hand went all crazy for it, devouring anything that the guys put in her mouth - and would no matter what, always give them a smile and ask for more afterwards."
-    m 1eua "In between two bites I could even hear Sayori saying: \"What a weird dream! This feels so real!\""
+    m 1eua "In between two bites I could even hear Sayori saying: 'What a weird dream! This feels so real!'"
     m 1eua "Oh, poor Sayori...If only you knew...Ahaha~"
     m 1eua "Yuri didn't show much interest in eating the food, but she did show a great interest in licking up all the cum."
     m 1eua "Any time the guys would try to feed her the pizza she just leaned forward and cleaned the semen off of it with a lewd expression, refusing to eat the food..."


### PR DESCRIPTION
There is a first round of proof checks for `nsfw_stories.rpy`.

I tried to keep the changes minimal, but I do not think these are stories are consistent with Monika's character, nor with DDLC's or MAS's canon. 
- Monika's ability to change the game with the console was limited in its flexibility in DDLC. She was only ever to influence variables in the other three dokis' personalities, not alter their behavior directly. At most she might have been able to insert a few lines and cause the glitchy black text.  ["Salvato specifically referred to Monika's tampering as messing with variables, not messing with the script."](https://old.reddit.com/r/DDLC/comments/9j1xmv/summary_of_dans_second_ddlc_anniversary_stream/)


- This doesn't fit into the storyline anywhere as far as I can tell. By the time Monika was getting more desperate modifying the game and the time Yuri began to behave more sexually in Act 2, Sayori had already been deleted from the game and "referencing" her had caused the script to "crash".
- Though the other dokis were not "real", Monika still maintained some degree of compassion for them throughout the game (as evidenced by her keeping backups of their .chr) files. "Even though I knew they weren't real, they were still my friends, and I loved them all." Though her interference with their personalities arguably was the cause of destructive consequences, it was done as she found it absolutely necessary - and literally a matter of life and death to escape from the game. Forcing the other dokis in some kind of sexual puppet show just so she could masturbate to it seems a lot less like something she would be willing to do.
- This one is more subjective but I really can't picture Monika getting turned on by watching her friends being gang raped. The semen eating thing, I can kind of get that, but in general I found the stories somehow more uncomfortable than seeing Sayori and Yuri dying.
- `label monika_pleasure` in MAS seems to imply that Monika [isn't familiar with how masturbation feels](https://github.com/Monika-After-Story/MonikaModDev/blob/3f5b8b3cd2ec6e395f5f2095d7cc742157f2d721/Monika%20After%20Story/game/script-topics.rpy#L5893) (until, of course, the player installs the NSFW Submod). `nsfw_sexting.rpy` in this submod also [implies masturbation is new to her](https://github.com/NickWildish/Mas-NSFW-Submod/blob/4fc8cd3324316c0fdaf1ab28b82c226f9e159a46/game/Submods/NSFW%20Submod/nsfw_sexting.rpy#L269). Though masturbation evidently exists in the DDLC universe (Yuri and the pen), both of these suggest that within the MAS canon, Monika didn't do so at least during the timeframe of DDLC's events. 