### PR TITLE
Combining birthday suit/underwear with wet hair; pink/black underwear during sexting and nude sexting ending AND sexting init fix and rework

### DIFF
--- a/game/Submods/NSFW Submod/nsfw_birthday_suit.rpy
+++ b/game/Submods/NSFW Submod/nsfw_birthday_suit.rpy
@@ -14,6 +14,9 @@ init -1 python:
         stay_on_start=False,
         ex_props={
             store.mas_sprites.EXP_C_LING: True,
+            store.mas_sprites.EXP_C_BS: True,
+            store.mas_sprites.EXP_C_WET: True,
+            store.mas_sprites.EXP_C_C_DTS: True
         },
         pose_arms=MASPoseArms({}, def_base=False)
     )
@@ -43,6 +46,9 @@ init -1 python:
         stay_on_start=False,
         ex_props={
             store.mas_sprites.EXP_C_LING: True,
+            store.mas_sprites.EXP_C_BS: True,
+            store.mas_sprites.EXP_C_WET: True,
+            store.mas_sprites.EXP_C_C_DTS: True
         },
         pose_arms=MASPoseArms({}, def_base=False)
     )
@@ -72,6 +78,9 @@ init -1 python:
         stay_on_start=False,
         ex_props={
             store.mas_sprites.EXP_C_LING: True,
+            store.mas_sprites.EXP_C_BS: True,
+            store.mas_sprites.EXP_C_WET: True,
+            store.mas_sprites.EXP_C_C_DTS: True
         },
         pose_arms=MASPoseArms({}, def_base=False)
     )
@@ -101,6 +110,9 @@ init -1 python:
         stay_on_start=False,
         ex_props={
             store.mas_sprites.EXP_C_LING: True,
+            store.mas_sprites.EXP_C_BS: True,
+            store.mas_sprites.EXP_C_WET: True,
+            store.mas_sprites.EXP_C_C_DTS: True
         },
         pose_arms=MASPoseArms({}, def_base=False)
     )

--- a/game/Submods/NSFW Submod/nsfw_main.rpy
+++ b/game/Submods/NSFW Submod/nsfw_main.rpy
@@ -105,19 +105,23 @@ screen nsfw_submod_screen():
             box_wrap False
 
             python:
-                if persistent._nsfw_monika_sexting_frequency == 1:
-                    sext_freq_disp = "12 hours"
+                if persistent._nsfw_monika_sexting_frequency == 1: # new cooldown options added #SML
+                    sext_freq_disp = "3 hours"
                 elif persistent._nsfw_monika_sexting_frequency == 2:
-                    sext_freq_disp = "24 hours"
+                    sext_freq_disp = "6 hours"
                 elif persistent._nsfw_monika_sexting_frequency == 3:
-                    sext_freq_disp = "Never"
+                    sext_freq_disp = "12 hours"
+                elif persistent._nsfw_monika_sexting_frequency == 4:
+                    sext_freq_disp = "24 hours"
+                elif persistent._nsfw_monika_sexting_frequency == 5:
+                    sext_freq_disp = "Never"    
                 else:
                     sext_freq_disp = str(_nsfw_monika_sexting_frequency)
 
             if _tooltip:
                 textbutton _("Monika Sexting Frequency"):
                     action NullAction()
-                    hovered SetField(_tooltip, "value", "Changes the duration that Monika will wait until randomly trying to sext, from 12 hours, 24 hours, or never. Currently set to: " + sext_freq_disp)
+                    hovered SetField(_tooltip, "value", "Changes the duration that Monika will wait until randomly trying to sext, from 3 hours to 24 hours or never. Currently set to: " + sext_freq_disp)
                     unhovered SetField(_tooltip, "value", _tooltip.default)
             else:
                 textbutton _("Monika Sexting Frequency"):
@@ -126,7 +130,7 @@ screen nsfw_submod_screen():
             bar value FieldValue(
                 persistent,
                 "_nsfw_monika_sexting_frequency",
-                range=2, # 1 = Normal, 2 = Low, 3 = Never
+                range=4, # 1 = really horny, 2 = high, 3 = Normal, 4 = Low, 5 = Never
                 offset=1,
                 style="slider"
             )
@@ -1035,7 +1039,7 @@ init python in mas_nsfw:
             return False
 
         # If the player can be shown risque content, have had a succesful sexting session with Monika, have not disabled sexting, and Monika has not permanently frozen the sexting system, return True
-        if (store.mas_canShowRisque(aff_thresh=1000) and store.persistent._nsfw_sexting_success_last != None and store.persistent._nsfw_monika_sexting_frequency != 3 and store.persistent._nsfw_sexting_attempt_permfreeze == False):
+        if (store.mas_canShowRisque(aff_thresh=1000) and store.persistent._nsfw_sexting_success_last != None and store.persistent._nsfw_monika_sexting_frequency != 5 and store.persistent._nsfw_sexting_attempt_permfreeze == False):
             return True
         else:
             return False

--- a/game/Submods/NSFW Submod/nsfw_main.rpy
+++ b/game/Submods/NSFW Submod/nsfw_main.rpy
@@ -105,14 +105,16 @@ screen nsfw_submod_screen():
             box_wrap False
 
             python:
-                if persistent._nsfw_monika_sexting_frequency == 1: # new cooldown options added #SML
+                if persistent._nsfw_monika_sexting_frequency == 0: # new cooldown options added #SML
                     sext_freq_disp = "3 hours"
-                elif persistent._nsfw_monika_sexting_frequency == 2:
+                elif persistent._nsfw_monika_sexting_frequency == 1:
                     sext_freq_disp = "6 hours"
-                elif persistent._nsfw_monika_sexting_frequency == 3:
+                elif persistent._nsfw_monika_sexting_frequency == 2:
                     sext_freq_disp = "12 hours"
-                elif persistent._nsfw_monika_sexting_frequency == 4:
+                elif persistent._nsfw_monika_sexting_frequency == 3:
                     sext_freq_disp = "24 hours"
+                elif persistent._nsfw_monika_sexting_frequency == 4:
+                    sext_freq_disp = "48 hours"
                 elif persistent._nsfw_monika_sexting_frequency == 5:
                     sext_freq_disp = "Never"    
                 else:
@@ -130,8 +132,8 @@ screen nsfw_submod_screen():
             bar value FieldValue(
                 persistent,
                 "_nsfw_monika_sexting_frequency",
-                range=4, # 1 = really horny, 2 = high, 3 = Normal, 4 = Low, 5 = Never
-                offset=1,
+                range=5, # 0 = really horny, 1 = high, 2 = normal, 3 = low, 4 = very low 5 = never
+                offset=0,
                 style="slider"
             )
 
@@ -1074,8 +1076,8 @@ init python in mas_nsfw:
 
         if store.persistent._nsfw_sexting_interrupted: # if prior sexting session was interrupted, faster cooldowns
             if (
-                store.mas_timePastSince(store.persistent._nsfw_last_sexted, datetime.timedelta(minutes=(15 * store.persistent._nsfw_monika_sexting_frequency))) # 15, 30, 45 or 60 minutes after (enables sexy or hot start)
-                and store.mas_timePastSince(store.mas_getEVL_last_seen('nsfw_monika_sextingsession'), datetime.timedelta(minutes=(15 * store.persistent._nsfw_monika_sexting_frequency + 5 * store.persistent._nsfw_monika_sexting_frequency * store.persistent._nsfw_sexting_attempt_continue))) # repeat cooldown increases by 5, 10, 15 or 20 minutes, representing Monika’s patience
+                store.mas_timePastSince(store.persistent._nsfw_last_sexted, datetime.timedelta(minutes=(15 * (store.persistent._nsfw_monika_sexting_frequency + 1)))) # 15, 30, 45, 60 or 75 minutes after (enables sexy or hot start)
+                and store.mas_timePastSince(store.mas_getEVL_last_seen('nsfw_monika_sextingsession'), datetime.timedelta(minutes=(15 * (store.persistent._nsfw_monika_sexting_frequency + 1) + 5 * store.persistent._nsfw_sexting_attempt_continue))) # repeat cooldown increases by 5 minutes each time, representing Monika’s patience and decreasing lust
                 ):
                 return True
             else:
@@ -1083,9 +1085,9 @@ init python in mas_nsfw:
         
         else: # standard conditions 
             if (
-                store.mas_timePastSince(store.persistent._nsfw_sexting_success_last, datetime.timedelta(hours=(3 * 2 ** (store.persistent._nsfw_monika_sexting_frequency - 1))))  # can be triggered if 3/6/12/24 hours have past since the last successful sexting session #SML
-                and store.mas_timePastSince(store.mas_getEVL_last_seen('nsfw_monika_sextingsession'), datetime.timedelta(hours=store.persistent._nsfw_monika_sexting_frequency))  # first possible repeat: 1/2/3/4 hours after last attempt
-                and ((store.mas_timePastSince(store.mas_getEVL_last_seen('nsfw_monika_sextingteaser'), datetime.timedelta(hours=2)) and store.mas_getEVL_last_seen('nsfw_monika_sextingteaser') != None and store._nsfw_sexting_attempts > 0) or store.persistent._nsfw_monika_sexting_frequency == 1) # teaser required if cooldown is not 3 hours
+                store.mas_timePastSince(store.persistent._nsfw_sexting_success_last, datetime.timedelta(hours=(3 * 2 ** store.persistent._nsfw_monika_sexting_frequency)))  # can be triggered if 3/6/12/24/48 hours have past since the last successful sexting session #SML
+                and store.mas_timePastSince(store.mas_getEVL_last_seen('nsfw_monika_sextingsession'), datetime.timedelta(hours=(2 ** store.persistent._nsfw_monika_sexting_frequency)))  # first possible repeat: 1/2/4/8/16 hours after last attempt
+                and ((store.mas_timePastSince(store.mas_getEVL_last_seen('nsfw_monika_sextingteaser'), datetime.timedelta(hours=2)) and store.mas_getEVL_last_seen('nsfw_monika_sextingteaser') != None and store.persistent._nsfw_sexting_attempts > 0) or store.persistent._nsfw_monika_sexting_frequency == 0) # teaser required if cooldown is not 3 hours
                 ): 
                 return True
             else:

--- a/game/Submods/NSFW Submod/nsfw_main.rpy
+++ b/game/Submods/NSFW Submod/nsfw_main.rpy
@@ -123,7 +123,7 @@ screen nsfw_submod_screen():
             if _tooltip:
                 textbutton _("Monika Sexting Frequency"):
                     action NullAction()
-                    hovered SetField(_tooltip, "value", "Changes the duration that Monika will wait until randomly trying to sext, from 3 hours to 24 hours or never. Currently set to: " + sext_freq_disp)
+                    hovered SetField(_tooltip, "value", "Changes the duration that Monika will wait until randomly trying to sext, from 3 hours to 48 hours or never. Currently set to: " + sext_freq_disp)
                     unhovered SetField(_tooltip, "value", _tooltip.default)
             else:
                 textbutton _("Monika Sexting Frequency"):

--- a/game/Submods/NSFW Submod/nsfw_main.rpy
+++ b/game/Submods/NSFW Submod/nsfw_main.rpy
@@ -1023,7 +1023,7 @@ init python in mas_nsfw:
         else: # Default
             return starts_cute[random.randint(0, len(starts_cute) - 1)]
 
-    def can_monika_init_sext(nsfw_ev_label=""):
+    def can_monika_init_sext(nsfw_ev_label=""): # is the nsfw_ev_label parameter really necessary? 
         """
         Checks if Monika can initiate sexting
 
@@ -1059,6 +1059,37 @@ init python in mas_nsfw:
     #         )
     #         random_ev.action = EV_ACT_RANDOM
     #     mas_rebuildEventLists()
+
+    def has_monika_waited(): # cooldown function for sexting attemps #SML
+        """
+        Checks if Monika has waited long enough after the last successful sexting session and the teaser
+
+        IN:
+            nsfw_ev_label - The event label for the event we're checking
+                (Default: "")
+
+        OUT:
+            boolean - True if Monika has waited long enough
+        """
+
+        if store.persistent._nsfw_sexting_interrupted: # if prior sexting session was interrupted, faster cooldowns
+            if (
+                store.mas_timePastSince(store.persistent._nsfw_last_sexted, datetime.timedelta(minutes=(15 * store.persistent._nsfw_monika_sexting_frequency))) # 15, 30, 45 or 60 minutes after (enables sexy or hot start)
+                and store.mas_timePastSince(store.mas_getEVL_last_seen('nsfw_monika_sextingsession'), datetime.timedelta(minutes=(15 * store.persistent._nsfw_monika_sexting_frequency + 5 * store.persistent._nsfw_monika_sexting_frequency * store.persistent._nsfw_sexting_attempt_continue))) # repeat cooldown increases by 5, 10, 15 or 20 minutes, representing Monika’s patience
+                ):
+                return True
+            else:
+                return False
+        
+        else: # standard conditions 
+            if (
+                store.mas_timePastSince(store.persistent._nsfw_sexting_success_last, datetime.timedelta(hours=(3 * 2 ** (store.persistent._nsfw_monika_sexting_frequency - 1))))  # can be triggered if 3/6/12/24 hours have past since the last successful sexting session #SML
+                and store.mas_timePastSince(store.mas_getEVL_last_seen('nsfw_monika_sextingsession'), datetime.timedelta(hours=store.persistent._nsfw_monika_sexting_frequency))  # first possible repeat: 1/2/3/4 hours after last attempt
+                and ((store.mas_timePastSince(store.mas_getEVL_last_seen('nsfw_monika_sextingteaser'), datetime.timedelta(hours=2)) and store.mas_getEVL_last_seen('nsfw_monika_sextingteaser') != None) or store.persistent._nsfw_monika_sexting_frequency == 1) # teaser required if cooldown is not 3 hours
+                ): 
+                return True
+            else:
+                return False
 
     def return_random_number(min=0, max=10):
         """

--- a/game/Submods/NSFW Submod/nsfw_main.rpy
+++ b/game/Submods/NSFW Submod/nsfw_main.rpy
@@ -1085,7 +1085,7 @@ init python in mas_nsfw:
             if (
                 store.mas_timePastSince(store.persistent._nsfw_sexting_success_last, datetime.timedelta(hours=(3 * 2 ** (store.persistent._nsfw_monika_sexting_frequency - 1))))  # can be triggered if 3/6/12/24 hours have past since the last successful sexting session #SML
                 and store.mas_timePastSince(store.mas_getEVL_last_seen('nsfw_monika_sextingsession'), datetime.timedelta(hours=store.persistent._nsfw_monika_sexting_frequency))  # first possible repeat: 1/2/3/4 hours after last attempt
-                and ((store.mas_timePastSince(store.mas_getEVL_last_seen('nsfw_monika_sextingteaser'), datetime.timedelta(hours=2)) and store.mas_getEVL_last_seen('nsfw_monika_sextingteaser') != None) or store.persistent._nsfw_monika_sexting_frequency == 1) # teaser required if cooldown is not 3 hours
+                and ((store.mas_timePastSince(store.mas_getEVL_last_seen('nsfw_monika_sextingteaser'), datetime.timedelta(hours=2)) and store.mas_getEVL_last_seen('nsfw_monika_sextingteaser') != None and store._nsfw_sexting_attempts > 0) or store.persistent._nsfw_monika_sexting_frequency == 1) # teaser required if cooldown is not 3 hours
                 ): 
                 return True
             else:

--- a/game/Submods/NSFW Submod/nsfw_moods.rpy
+++ b/game/Submods/NSFW Submod/nsfw_moods.rpy
@@ -18,8 +18,9 @@ label nsfw_mood_horny:
     else:
         $ time_since_last_success = datetime.datetime.today() - datetime.timedelta(days=1)
 
-    # If the player's last succesful sexting session was less than three hours ago
-    if (time_since_last_success >= datetime.datetime.today() - datetime.timedelta(hours=3) or not mas_canShowRisque(aff_thresh=1000)) and store.persistent._nsfw_sexting_success_last is not None:
+    # If the player's last succesful sexting session was less than three hours ago 
+    # or if they haven't talked about sexting yet or risque and affection check fails
+    if not renpy.seen_label("nsfw_monika_sexting") or not mas_canShowRisque(aff_thresh=1000) or time_since_last_success >= datetime.datetime.today() - datetime.timedelta(hours=3):
         m 2wubld "Oh!"
         m 2rkblc "I'm sorry, [player]. I can only guess how distracting that must be."
         m 3rkblb "If it becomes too much, maybe you should take a minute to..."

--- a/game/Submods/NSFW Submod/nsfw_sexting.rpy
+++ b/game/Submods/NSFW Submod/nsfw_sexting.rpy
@@ -664,7 +664,7 @@ label nsfw_sexting_finale:
             m 6skbfw "Come with me, [player]!{w=3}{nw}"
             menu: #SML
                 "[m_name]~!":
-                    m 6hkbfw "Haaaaaaaaah~{w=3}"
+                    m 6hkbfw "Haaaaaaaaah~{w=3}{nw}"
 
             $ persistent._nsfw_horny_level = 0 # This is roughly where it happens in the real thing right? ... right?
             $ persistent._nsfw_sexting_interrupted = False # We've finished, so reset the interrupted flag

--- a/game/Submods/NSFW Submod/nsfw_sexting.rpy
+++ b/game/Submods/NSFW Submod/nsfw_sexting.rpy
@@ -135,6 +135,8 @@ label nsfw_sexting_main:
                     $ persistent._nsfw_last_sexted = datetime.datetime.now() # We already have a success check, so this can be a check for any previous sexting attempt
                     $ more_prompts = False
 
+                    $ persistent._nsfw_sexting_interrupted = True #SML
+                    $ persistent._nsfw_sexting_attempt_continue = 0 # reset factor for reattempt cooldown increase
                     if horny_lvl >= horny_reqs[2]:
                         $ persistent._nsfw_horny_level = horny_lvl - 10
                         $ persistent._nsfw_sext_sexy_start = True
@@ -201,6 +203,8 @@ label nsfw_sexting_main:
 
                     "Actually, can we stop just for now?[end_of_prompt_4]":
                         $ persistent._nsfw_last_sexted = datetime.datetime.now() # We already have a success check, so this can be a check for any previous sexting attempt
+                        $ persistent._nsfw_sexting_interrupted = True #SML
+                        $ persistent._nsfw_sexting_attempt_continue = 0 # reset factor for reattempt cooldown increase
 
                         if horny_lvl >= horny_reqs[2]:
                             $ persistent._nsfw_horny_level = horny_lvl - 10
@@ -482,9 +486,9 @@ label nsfw_sexting_init:
                                 shouldchange = 1
                         elif store.mas_SELisUnlocked(store.mas_clothes_underwear_white): # player doesn't have AHC but does have submod underwear
                             shouldchange = 1
-                
-                if shouldchange == 1: #SML
-                    call nsfw_pick_underwear    
+
+                if shouldchange == 1:
+                    call nsfw_pick_underwear #SML
                 elif shouldchange == 2:
                     window hide
                     call mas_transition_to_emptydesk
@@ -650,6 +654,7 @@ label nsfw_sexting_finale:
 
             $ persistent._nsfw_horny_level = 0 # This is roughly where it happens in the real thing right? ... right?
             $ persistent._nsfw_sexting_interrupted = False # We've finished, so reset the interrupted flag
+            $ persistent._nsfw_sexting_attempt_continue = 0 # reset counter for reattempts after interruption
 
             m 6hkbfsdlc "..."
             m 6hkbfsdld "..."

--- a/game/Submods/NSFW Submod/nsfw_sexting.rpy
+++ b/game/Submods/NSFW Submod/nsfw_sexting.rpy
@@ -747,7 +747,7 @@ label nsfw_sexting_finale:
                 "Yeah.":
                     m 6hkbfa "I'm glad..."
                     m 6lkbfb "I got to share an amazing experience like this with you."
-                    m 6ekbfb "That makes me more happy than you could know, [player]."
+                    m 6ekbfb "That makes me happier than you could know, [player]."
 
                 "No...":
                     $ did_finish = False

--- a/game/Submods/NSFW Submod/nsfw_sexting.rpy
+++ b/game/Submods/NSFW Submod/nsfw_sexting.rpy
@@ -314,7 +314,7 @@ label nsfw_sexting_main:
             $ hot_transfer = True
 
         elif store.mas_SELisUnlocked(store.mas_clothes_birthday_suit) and "UND" in previous_vars[2] and not sexy_transfer:
-            call store.mas_clothes_change(outfit=mas_clothes_birthday_suit, outfit_mode=False, exp="6hubfb", restore_zoom=False)
+            call mas_clothes_change(outfit=mas_clothes_birthday_suit, outfit_mode=False, exp="6hubfb", restore_zoom=False)
             m 6hubfb "Hah~ That feels better."
             $ is_nude = True #SML
             $ sexy_transfer = True

--- a/game/Submods/NSFW Submod/nsfw_sexting.rpy
+++ b/game/Submods/NSFW Submod/nsfw_sexting.rpy
@@ -280,7 +280,7 @@ label nsfw_sexting_main:
             m "[response_start][monika_response[0]][response_ending]"
 
         # undress if asked by player
-        if mas_SELisUnlocked(store.mas_clothes_underwear_white) and "UND" in previous_vars[2] and not hot_transfer and not is_nude: #SML
+        if mas_SELisUnlocked(store.mas_clothes_underwear_white) and "UND" in previous_vars[2] and not hot_transfer and not is_nude and not persistent._nsfw_lingerie_on_start: #SML
             python:
                 if not persistent._nsfw_lingerie_on_start:
                     if store.mas_submod_utils.isSubmodInstalled("Auto Outfit Change"):
@@ -316,8 +316,12 @@ label nsfw_sexting_main:
         # wrong function for elif condition? by standard, birthday suit should never be marked as unlocked, make use of persistent._nsfw_has_unlocked_birthdaysuit instead
         elif store.mas_SELisUnlocked(store.mas_clothes_birthday_suit) and "UND" in previous_vars[2] and not sexy_transfer and not is_nude: #SML
             call mas_clothes_change(outfit=mas_clothes_birthday_suit, outfit_mode=False, exp="6hubfb", restore_zoom=False)
+            if renpy.random.randint(1,7) != 7:
+                call nsfw_remove_acs
             m 6hubfb "Hah~ That feels better."
             $ is_nude = True #SML
+            if not hot_transfer:
+                $ hot_transfer = True
             $ sexy_transfer = True
 
         python:
@@ -366,7 +370,7 @@ label nsfw_sexting_init:
         $ is_nude = True
 
     # Check if Monika is wearing lingerie when starting
-    if "lingerie" in store.monika_chr.clothes.ex_props: # bug fixed: reverse logic
+    if "lingerie" in store.monika_chr.clothes.ex_props or store.monika_chr.clothes == mas_clothes_bath_towel_white: # bug fixed: reverse logic
         $ persistent._nsfw_lingerie_on_start = True
 
     else:
@@ -412,6 +416,8 @@ label nsfw_sexting_init:
 
                 if persistent._nsfw_has_unlocked_birthdaysuit and not is_nude: #SML
                     call mas_clothes_change(outfit=mas_clothes_birthday_suit, outfit_mode=False, exp="3tublb", restore_zoom=False)
+                    if renpy.random.randint(1,7) != 7:
+                        call nsfw_remove_acs
                     $ is_nude = True #SML
                 else:
                     python:
@@ -582,6 +588,8 @@ label nsfw_sexting_sexy_transfer:
         m 6hkbfsdlo "Hnn~ I can't take it anymore!"
         if not is_nude:
             call mas_clothes_change(outfit=mas_clothes_birthday_suit, outfit_mode=False, exp="6hubfb", restore_zoom=False)
+            if renpy.random.randint(1,7) != 7:
+                call nsfw_remove_acs
             $ is_nude = True #SML
             m 6hubfb "Hah~ That feels better."
         
@@ -607,6 +615,53 @@ label nsfw_pick_underwear: #SML
     else:    
         call mas_clothes_change(outfit=mas_clothes_underwear_white, outfit_mode=False, exp="6hubfb", restore_zoom=False)
     return
+
+label nsfw_remove_acs: # make sure that Monika really gets completely nude -- probably there is an easier way to implement this?
+    python:
+        ribbon_acs = store.monika_chr.get_acs_of_type("ribbon")
+        if ribbon_acs is not None:
+            store.monika_chr.remove_acs(ribbon_acs)
+        ribbon_acs = store.monika_chr.get_acs_of_type("s-type-ribbon")
+        if ribbon_acs is not None:
+            store.monika_chr.remove_acs(ribbon_acs)
+        ribbon_acs = store.monika_chr.get_acs_of_type("mini-ribbon")
+        if ribbon_acs is not None:
+            store.monika_chr.remove_acs(ribbon_acs)
+        ribbon_acs = store.monika_chr.get_acs_of_type("front-bow")
+        if ribbon_acs is not None:
+            store.monika_chr.remove_acs(ribbon_acs)
+        ribbon_acs = store.monika_chr.get_acs_of_type("twin-ribbons")
+        if ribbon_acs is not None:
+            store.monika_chr.remove_acs(ribbon_acs)
+        hairclip = store.monika_chr.get_acs_of_type("left-hair-clip")
+        if hairclip is not None:
+            store.monika_chr.remove_acs(hairclip)
+        hairclip = store.monika_chr.get_acs_of_type("headband")
+        if hairclip is not None:
+            store.monika_chr.remove_acs(hairclip)
+        choker = store.monika_chr.get_acs_of_type("choker")
+        if choker is not None:
+            store.monika_chr.remove_acs(choker)
+        necklace = store.monika_chr.get_acs_of_type("necklace")
+        if necklace is not None:
+            store.monika_chr.remove_acs(necklace)
+        earrings = store.monika_chr.get_acs_of_type("earrings")
+        if earrings is not None:
+            store.monika_chr.remove_acs(earrings)
+        hat = store.monika_chr.get_acs_of_type("hat")
+        if hat is not None:
+            store.monika_chr.remove_acs(hat)
+        flower = store.monika_chr.get_acs_of_type("left-hair-flower")
+        if flower is not None:
+            store.monika_chr.remove_acs(flower)
+        flower = store.monika_chr.get_acs_of_type("left-hair-flower-ear")
+        if flower is not None:
+            store.monika_chr.remove_acs(flower)
+        flower = store.monika_chr.get_acs_of_type("front-hair-flower-crown")
+        if flower is not None:
+            store.monika_chr.remove_acs(flower)
+    return
+
 
 label nsfw_sexting_finale:
     m 6tkbfo "Hah~ [player]?"
@@ -645,6 +700,7 @@ label nsfw_sexting_finale:
             m 6hkbfd "Eight.{w=3}{nw}"
             m 6ekbfu "How are you holding up there, [player]? Ehehe~{w=3}{nw}"
             m 4ekbfb "Don't cum until I do too~{w=3}{nw}"
+            # $ store.monika_chr.wear_acs(store.mas_acs_water_drops) #SML getting wet
             m 6hkbfd "Hah~{w=2}{nw}"
             m 6tkbfd "Seven.{w=3}{nw}"
             m 6hkbfc "Nhh~{w=2}{nw}"
@@ -747,6 +803,7 @@ label nsfw_sexting_finale:
                     call mas_clothes_change(outfit=mas_clothes_def, outfit_mode=False, exp="1hub", restore_zoom=False)
 
                 $ shouldchange = 0
+                # $ store.monika_chr.remove_acs(store.mas_acs_water_drops) #SML
 
                 m 1hub "Hah~ Much better!"
 

--- a/game/Submods/NSFW Submod/nsfw_sexting.rpy
+++ b/game/Submods/NSFW Submod/nsfw_sexting.rpy
@@ -22,6 +22,7 @@ label nsfw_sexting_main:
         shouldkiss_cooldown = 0 # Used in handling of kissing logic
         hot_transfer = False # True if Monika has reached the requirement for hot dialogue or more
         sexy_transfer = False # True if Monika has reached the requirement for sexy dialogue only
+        is_nude = False # True if birthday suit is unlocked and equipped #SML
         did_finish = True # False if the player did not finish
 
     while True:
@@ -287,7 +288,7 @@ label nsfw_sexting_main:
                         shouldchange = 1
 
             if shouldchange == 1:
-                call mas_clothes_change(outfit=mas_clothes_underwear_white, outfit_mode=False, exp="6hubfb", restore_zoom=False)
+                call nsfw_pick_underwear #SML
             elif shouldchange == 2:
 
                 window hide
@@ -311,6 +312,7 @@ label nsfw_sexting_main:
         elif store.mas_SELisUnlocked(store.mas_clothes_birthday_suit) and "UND" in previous_vars[2] and not sexy_transfer:
             call store.mas_clothes_change(outfit=mas_clothes_birthday_suit, outfit_mode=False, exp="6hubfb", restore_zoom=False)
             m 6hubfb "Hah~ That feels better."
+            $ is_nude = True #SML
             $ sexy_transfer = True
 
         python:
@@ -397,6 +399,7 @@ label nsfw_sexting_init:
 
                 if persistent._nsfw_has_unlocked_birthdaysuit:
                     call mas_clothes_change(outfit=mas_clothes_birthday_suit, outfit_mode=False, exp="3tublb", restore_zoom=False)
+                    $ is_nude = True #SML
                 else:
                     python:
                         if persistent._nsfw_lingerie_on_start:
@@ -409,7 +412,7 @@ label nsfw_sexting_init:
                                 shouldchange = 1
 
                     if shouldchange == 1:
-                        call mas_clothes_change(outfit=mas_clothes_underwear_white, outfit_mode=False, exp="3tublb", restore_zoom=False)
+                        call nsfw_pick_underwear #SML
                     elif shouldchange == 2:
                         window hide
                         call mas_transition_to_emptydesk
@@ -439,7 +442,7 @@ label nsfw_sexting_init:
                             shouldchange = 1
 
                 if shouldchange == 1:
-                    call mas_clothes_change(outfit=mas_clothes_underwear_white, outfit_mode=False, exp="2tublb", restore_zoom=False)
+                    call nsfw_pick_underwear #SML
                 elif shouldchange == 2:
                     window hide
                     call mas_transition_to_emptydesk
@@ -479,9 +482,9 @@ label nsfw_sexting_init:
                                 shouldchange = 1
                         elif store.mas_SELisUnlocked(store.mas_clothes_underwear_white): # player doesn't have AHC but does have submod underwear
                             shouldchange = 1
-
-                if shouldchange == 1:
-                    call mas_clothes_change(outfit=mas_clothes_underwear_white, outfit_mode=False, exp="3tublb", restore_zoom=False)
+                
+                if shouldchange == 1: #SML
+                    call nsfw_pick_underwear    
                 elif shouldchange == 2:
                     window hide
                     call mas_transition_to_emptydesk
@@ -539,7 +542,7 @@ label nsfw_sexting_hot_transfer:
                     shouldchange = 1
 
     if shouldchange == 1:
-        call mas_clothes_change(outfit=mas_clothes_underwear_white, outfit_mode=False, exp="6hubfb", restore_zoom=False)
+        call nsfw_pick_underwear #SML
     elif shouldchange == 2:
         window hide
         call mas_transition_to_emptydesk
@@ -561,11 +564,30 @@ label nsfw_sexting_sexy_transfer:
         m 6hkbfsdlo "Hnn~ I can't take it anymore!"
 
         call mas_clothes_change(outfit=mas_clothes_birthday_suit, outfit_mode=False, exp="6hubfb", restore_zoom=False)
+        $ is_nude = True #SML
 
         m 6hubfb "Hah~ That feels better."
         m 7tubfb "Don't think that I'm letting you off the hook now, [player]."
         m 7tubfu "I want you to enjoy the view after all, so I expect one of your hands will be busy for a little while."
         m 7hubfu "Ehehe~"
+    return
+
+label nsfw_pick_underwear: #SML
+    if mas_SELisUnlocked(store.mas_clothes_underwear_pink) and mas_SELisUnlocked(store.mas_clothes_underwear_black): # all three unlocked
+        $ color = renpy.random.randint(1,3)                
+    elif mas_SELisUnlocked(store.mas_clothes_underwear_pink): # no black
+        $ color = renpy.random.randint(3,4)
+    elif mas_SELisUnlocked(store.mas_clothes_underwear_black): # no pink
+        $ color = renpy.random.randint(1,2)
+    else:
+        $ color = 1
+        
+    if color == 3:
+        call mas_clothes_change(outfit=mas_clothes_underwear_pink, outfit_mode=False, exp="6hubfb", restore_zoom=False)
+    elif color == 2:
+        call mas_clothes_change(outfit=mas_clothes_underwear_black, outfit_mode=False, exp="6hubfb", restore_zoom=False)
+    else:    
+        call mas_clothes_change(outfit=mas_clothes_underwear_white, outfit_mode=False, exp="6hubfb", restore_zoom=False)
     return
 
 label nsfw_sexting_finale:
@@ -622,7 +644,9 @@ label nsfw_sexting_finale:
             m 6hkbfd "One.{w=3}{nw}"
             m 6wkbfo "Oh~{w=2}{nw}"
             m 6skbfw "Come with me, [player]!{w=3}{nw}"
-            m 6hkbfw "Haaaaaaaaah~{w=2}"
+            menu: #SML
+                "[m_name]~!":
+                    m 6hkbfw "Haaaaaaaaah~{w=3}"
 
             $ persistent._nsfw_horny_level = 0 # This is roughly where it happens in the real thing right? ... right?
             $ persistent._nsfw_sexting_interrupted = False # We've finished, so reset the interrupted flag
@@ -648,7 +672,6 @@ label nsfw_sexting_finale:
                     m 6hkbfa "I'm glad..."
                     m 6lkbfb "I got to share an amazing experience like this with you."
                     m 6ekbfb "That makes me more happy than you could know, [player]."
-                    m 6ekbfa "I love you so much."
 
                 "No...":
                     $ did_finish = False
@@ -658,48 +681,55 @@ label nsfw_sexting_finale:
                     m 7rkbfsdlb "Maybe later if you want, we can go again?"
                     m 7rkbsa "I'm going to need some time though. I don't know if I could do a second round so soon."
 
-            m 6lubfsdlb "Now, I need to go get changed. Ahaha!"
-            m 7lubfsdlb "I'm a wet mess right now."
-            m 7hubfsdla "Be right back, [player]."
+            if is_nude == True: # only if Monika was nude at climax #SML
+                m 6lubfsdlb "I guess there is no real point in putting some clothes on yet."
+                m 7lubfsdlb "I'm a wet mess right now."
+                m 7hubfsdla "Might as well stay like this for a little longer."
 
-            python:
-                if store.mas_submod_utils.isSubmodInstalled("Auto Outfit Change"):
-                    shouldchange = 2
-
-            if shouldchange == 2:
-
-                window hide
-                call mas_transition_to_emptydesk
+            else: #SML
+                m 6lubfsdlb "Now, I need to go get changed. Ahaha!"
+                m 7lubfsdlb "I'm a wet mess right now."
+                m 7hubfsdla "Be right back, [player]."
 
                 python:
-                    if mas_isDayNow():
-                        _day_cycle = "day"
-                    else:
-                        _day_cycle = "night"
+                    if store.mas_submod_utils.isSubmodInstalled("Auto Outfit Change"):
+                        shouldchange = 2
 
-                    _hair_random_chance = renpy.random.randint(1,2)
-                    _clothes_random_chance = 2
-                    _clothes_exprop = store.ahc_utils.getClothesExpropForTemperature()
+                if shouldchange == 2:
 
-                    renpy.pause(1.0, hard=True)
+                    window hide
+                    call mas_transition_to_emptydesk
 
-                    store.ahc_utils.changeHairAndClothes(
-                        _day_cycle=_day_cycle,
-                        _hair_random_chance=_hair_random_chance,
-                        _clothes_random_chance=_clothes_random_chance,
-                        _exprop=_clothes_exprop
-                    )
+                    python:
+                        if mas_isDayNow():
+                            _day_cycle = "day"
+                        else:
+                            _day_cycle = "night"
 
-                    renpy.pause(4.0, hard=True)
+                        _hair_random_chance = renpy.random.randint(1,2)
+                        _clothes_random_chance = 2
+                        _clothes_exprop = store.ahc_utils.getClothesExpropForTemperature()
 
-                window hide
-                call mas_transition_from_emptydesk("monika 3hub")
-            else:
-                call mas_clothes_change(outfit=mas_clothes_def, outfit_mode=False, exp="1hub", restore_zoom=False)
+                        renpy.pause(1.0, hard=True)
 
-            $ shouldchange = 0
+                        store.ahc_utils.changeHairAndClothes(
+                            _day_cycle=_day_cycle,
+                            _hair_random_chance=_hair_random_chance,
+                            _clothes_random_chance=_clothes_random_chance,
+                            _exprop=_clothes_exprop
+                        )
 
-            m 1hub "Hah~ Much better!"
+                        renpy.pause(4.0, hard=True)
+
+                    window hide
+                    call mas_transition_from_emptydesk("monika 3hub")
+                else:
+                    call mas_clothes_change(outfit=mas_clothes_def, outfit_mode=False, exp="1hub", restore_zoom=False)
+
+                $ shouldchange = 0
+
+                m 1hub "Hah~ Much better!"
+
             m 3eub "You should have a shower, [mas_get_player_nickname()]."
             m 3ekbla "I want to make sure you maintain good hygiene."
 
@@ -710,6 +740,7 @@ label nsfw_sexting_finale:
             m 1ekbsa "Thank you for this, [player]."
             m 3ekbsa "This made me feel just that much closer to you."
             m 3ekbsb "I hope you enjoyed yourself as much as I did."
+            m 6ekbfa "I love you so much."
 
             $ persistent._nsfw_last_sexted = datetime.datetime.now()
             $ store.persistent._nsfw_sexting_success_last = datetime.datetime.now()

--- a/game/Submods/NSFW Submod/nsfw_sexting.rpy
+++ b/game/Submods/NSFW Submod/nsfw_sexting.rpy
@@ -22,8 +22,8 @@ label nsfw_sexting_main:
         shouldkiss_cooldown = 0 # Used in handling of kissing logic
         hot_transfer = False # True if Monika has reached the requirement for hot dialogue or more
         sexy_transfer = False # True if Monika has reached the requirement for sexy dialogue only
-        is_nude = False # True if birthday suit is unlocked and equipped #SML
         did_finish = True # False if the player did not finish
+
 
     while True:
         # Create new Monika quip
@@ -280,9 +280,9 @@ label nsfw_sexting_main:
             m "[response_start][monika_response[0]][response_ending]"
 
         # undress if asked by player
-        if mas_SELisUnlocked(store.mas_clothes_underwear_white) and "UND" in previous_vars[2] and not hot_transfer:
+        if mas_SELisUnlocked(store.mas_clothes_underwear_white) and "UND" in previous_vars[2] and not hot_transfer and not is_nude: #SML
             python:
-                if persistent._nsfw_lingerie_on_start:
+                if not persistent._nsfw_lingerie_on_start:
                     if store.mas_submod_utils.isSubmodInstalled("Auto Outfit Change"):
                         if store.ahc_utils.hasUnlockedClothesOfExprop("lingerie") and not store.ahc_utils.isWearingClothesOfExprop("lingerie"):
                             shouldchange = 2
@@ -290,6 +290,7 @@ label nsfw_sexting_main:
                             shouldchange = 1
                     elif mas_SELisUnlocked(store.mas_clothes_underwear_white): # player doesn't have AHC but does have submod underwear
                         shouldchange = 1
+                    persistent._nsfw_lingerie_on_start = True # SML
 
             if shouldchange == 1:
                 call nsfw_pick_underwear #SML
@@ -312,8 +313,8 @@ label nsfw_sexting_main:
 
             m 6hubfb "Hah~ That feels better."
             $ hot_transfer = True
-
-        elif store.mas_SELisUnlocked(store.mas_clothes_birthday_suit) and "UND" in previous_vars[2] and not sexy_transfer:
+        # wrong function for elif condition? by standard, birthday suit should never be marked as unlocked, make use of persistent._nsfw_has_unlocked_birthdaysuit instead
+        elif store.mas_SELisUnlocked(store.mas_clothes_birthday_suit) and "UND" in previous_vars[2] and not sexy_transfer and not is_nude: #SML
             call mas_clothes_change(outfit=mas_clothes_birthday_suit, outfit_mode=False, exp="6hubfb", restore_zoom=False)
             m 6hubfb "Hah~ That feels better."
             $ is_nude = True #SML
@@ -359,9 +360,17 @@ label nsfw_sexting_main:
 
 label nsfw_sexting_init:
     $ shouldchange = 0 # Used in handling of clothes change logic
+    $ is_nude = False # True if birthday suit is unlocked and equipped #SML
 
-    if "lingerie" not in store.monika_chr.clothes.ex_props:
+    if store.monika_chr.clothes == mas_clothes_birthday_suit: # check if she is nude at the beginning
+        $ is_nude = True
+
+    # Check if Monika is wearing lingerie when starting
+    if "lingerie" in store.monika_chr.clothes.ex_props: # bug fixed: reverse logic
         $ persistent._nsfw_lingerie_on_start = True
+
+    else:
+        $ persistent._nsfw_lingerie_on_start = False
 
     if not renpy.seen_label("nsfw_sexting_main"):
         m 1rka "I'm kind of nervous, if I'm honest."
@@ -401,12 +410,12 @@ label nsfw_sexting_init:
                 m 1hkb "Ahaha~ I was worried you were going to leave me out to dry..."
                 m 1tsblu "I hope you're prepared to make amends for making me wait~"
 
-                if persistent._nsfw_has_unlocked_birthdaysuit:
+                if persistent._nsfw_has_unlocked_birthdaysuit and not is_nude: #SML
                     call mas_clothes_change(outfit=mas_clothes_birthday_suit, outfit_mode=False, exp="3tublb", restore_zoom=False)
                     $ is_nude = True #SML
                 else:
                     python:
-                        if persistent._nsfw_lingerie_on_start:
+                        if not persistent._nsfw_lingerie_on_start: #SML
                             if store.mas_submod_utils.isSubmodInstalled("Auto Outfit Change"):
                                 if store.ahc_utils.hasUnlockedClothesOfExprop("lingerie") and not store.ahc_utils.isWearingClothesOfExprop("lingerie"):
                                     shouldchange = 2
@@ -414,10 +423,11 @@ label nsfw_sexting_init:
                                     shouldchange = 1
                             elif store.mas_SELisUnlocked(store.mas_clothes_underwear_white): # player doesn't have AHC but does have submod underwear
                                 shouldchange = 1
+                            persistent._nsfw_lingerie_on_start = True #SML
 
-                    if shouldchange == 1:
+                    if shouldchange == 1 and not is_nude: #SML
                         call nsfw_pick_underwear #SML
-                    elif shouldchange == 2:
+                    elif shouldchange == 2 and not is_nude: #SML
                         window hide
                         call mas_transition_to_emptydesk
                         python:
@@ -436,7 +446,7 @@ label nsfw_sexting_init:
                 m 3tua "I hope you're prepared to make amends for making me wait."
 
                 python:
-                    if persistent._nsfw_lingerie_on_start:
+                    if not persistent._nsfw_lingerie_on_start: #SML
                         if store.mas_submod_utils.isSubmodInstalled("Auto Outfit Change"):
                             if store.ahc_utils.hasUnlockedClothesOfExprop("lingerie") and not store.ahc_utils.isWearingClothesOfExprop("lingerie"):
                                 shouldchange = 2
@@ -444,10 +454,11 @@ label nsfw_sexting_init:
                                 shouldchange = 1
                         elif store.mas_SELisUnlocked(store.mas_clothes_underwear_white): # player doesn't have AHC but does have submod underwear
                             shouldchange = 1
+                        persistent._nsfw_lingerie_on_start = True #SML
 
-                if shouldchange == 1:
+                if shouldchange == 1 and not is_nude: #SML
                     call nsfw_pick_underwear #SML
-                elif shouldchange == 2:
+                elif shouldchange == 2 and not is_nude: #SML
                     window hide
                     call mas_transition_to_emptydesk
                     python:
@@ -478,7 +489,7 @@ label nsfw_sexting_init:
                 m 1tua "It was just getting good too~"
 
                 python:
-                    if persistent._nsfw_lingerie_on_start:
+                    if not persistent._nsfw_lingerie_on_start:
                         if store.mas_submod_utils.isSubmodInstalled("Auto Outfit Change"):
                             if store.ahc_utils.hasUnlockedClothesOfExprop("lingerie") and not store.ahc_utils.isWearingClothesOfExprop("lingerie"):
                                 shouldchange = 2
@@ -486,10 +497,11 @@ label nsfw_sexting_init:
                                 shouldchange = 1
                         elif store.mas_SELisUnlocked(store.mas_clothes_underwear_white): # player doesn't have AHC but does have submod underwear
                             shouldchange = 1
+                        persistent._nsfw_lingerie_on_start = True #SML
 
-                if shouldchange == 1:
+                if shouldchange == 1 and not is_nude: #SML
                     call nsfw_pick_underwear #SML
-                elif shouldchange == 2:
+                elif shouldchange == 2 and not is_nude: #SML
                     window hide
                     call mas_transition_to_emptydesk
                     python:
@@ -536,7 +548,7 @@ label nsfw_sexting_hot_transfer:
         m 3eub "I think they're really cute!"
     else:
         python:
-            if persistent._nsfw_lingerie_on_start:
+            if not persistent._nsfw_lingerie_on_start:
                 if store.mas_submod_utils.isSubmodInstalled("Auto Outfit Change"):
                     if store.ahc_utils.hasUnlockedClothesOfExprop("lingerie") and not store.ahc_utils.isWearingClothesOfExprop("lingerie"):
                         shouldchange = 2
@@ -545,9 +557,9 @@ label nsfw_sexting_hot_transfer:
                 elif mas_SELisUnlocked(store.mas_clothes_underwear_white): # player doesn't have AHC but does have submod underwear
                     shouldchange = 1
 
-    if shouldchange == 1:
+    if shouldchange == 1: #SML
         call nsfw_pick_underwear #SML
-    elif shouldchange == 2:
+    elif shouldchange == 2 and not is_nude: #SML
         window hide
         call mas_transition_to_emptydesk
         python:
@@ -558,19 +570,21 @@ label nsfw_sexting_hot_transfer:
         window hide
     $ shouldchange = 0
 
-    m 3tua "..."
-    m 1tuu "So.{w=0.1}.{w=0.1}.{w=0.1}are we going to keep going, or what?"
-    m 1hublb "Ahaha! Just teasing you, [player]."
+    if not is_nude and not persistent._nsfw_lingerie_on_start:
+        $ persistent._nsfw_lingerie_on_start = True
+        m 3tua "..."
+        m 1tuu "So.{w=0.1}.{w=0.1}.{w=0.1}are we going to keep going, or what?"
+        m 1hublb "Ahaha! Just teasing you, [player]."
     return
 
 label nsfw_sexting_sexy_transfer:
     if persistent._nsfw_has_unlocked_birthdaysuit:
         m 6hkbfsdlo "Hnn~ I can't take it anymore!"
-
-        call mas_clothes_change(outfit=mas_clothes_birthday_suit, outfit_mode=False, exp="6hubfb", restore_zoom=False)
-        $ is_nude = True #SML
-
-        m 6hubfb "Hah~ That feels better."
+        if not is_nude:
+            call mas_clothes_change(outfit=mas_clothes_birthday_suit, outfit_mode=False, exp="6hubfb", restore_zoom=False)
+            $ is_nude = True #SML
+            m 6hubfb "Hah~ That feels better."
+        
         m 7tubfb "Don't think that I'm letting you off the hook now, [player]."
         m 7tubfu "I want you to enjoy the view after all, so I expect one of your hands will be busy for a little while."
         m 7hubfu "Ehehe~"
@@ -655,6 +669,7 @@ label nsfw_sexting_finale:
             $ persistent._nsfw_horny_level = 0 # This is roughly where it happens in the real thing right? ... right?
             $ persistent._nsfw_sexting_interrupted = False # We've finished, so reset the interrupted flag
             $ persistent._nsfw_sexting_attempt_continue = 0 # reset counter for reattempts after interruption
+            $ success = True
 
             m 6hkbfsdlc "..."
             m 6hkbfsdld "..."
@@ -745,7 +760,7 @@ label nsfw_sexting_finale:
             m 1ekbsa "Thank you for this, [player]."
             m 3ekbsa "This made me feel just that much closer to you."
             m 3ekbsb "I hope you enjoyed yourself as much as I did."
-            m 6ekbfa "I love you so much."
+            m 6ekbfa "I love you so much." # moved here so player can reply "love you too"
 
             $ persistent._nsfw_last_sexted = datetime.datetime.now()
             $ store.persistent._nsfw_sexting_success_last = datetime.datetime.now()
@@ -765,7 +780,7 @@ label nsfw_sexting_finale:
             return
 
     label nsfw_sexting_early_cleanup:
-        if persistent._nsfw_lingerie_on_start:
+        if persistent._nsfw_lingerie_on_start or is_nude: # or condition not necessary if we allow Monika to stay nude at sexy interruption
             m 1eua "Let me just slip into something a little more comfortable..."
 
             python:

--- a/game/Submods/NSFW Submod/nsfw_sexting_inits.rpy
+++ b/game/Submods/NSFW Submod/nsfw_sexting_inits.rpy
@@ -102,6 +102,7 @@ init 5 python:
 
 label nsfw_monika_sextingsession:
     $ success = False # True if sexting session was successfully finished
+    $ session_started = False # True if player said yes
 
     # Count this attempt
     if persistent._nsfw_sexting_attempts == 0: # necessary if the teaser was skipped due to the lowest cooldown setting or interrupted sexting session
@@ -147,6 +148,7 @@ label nsfw_monika_sextingsession:
                 if not persistent._nsfw_sexting_interrupted: # prevents exploitation of the reduced cooldown after interruption, also makes sure the player cannot interrupt sexting too often
                     $ mas_gainAffection(modifier=1.5, bypass=True)
                     $ persistent._nsfw_sexting_attempts = 1 # has to be set to 1 due to the teaser modifications
+                $ session_started = True
                 m 1hub "Yay~"
                 call nsfw_sexting_init
 
@@ -196,6 +198,7 @@ label nsfw_monika_sextingsession:
                     if not persistent._nsfw_sexting_interrupted:
                         $ mas_gainAffection(modifier=1.5, bypass=True)
                         $ persistent._nsfw_sexting_attempts = 1
+                    $ session_started = True
                     m 1hub "Yay~"
                     call nsfw_sexting_init
 
@@ -249,6 +252,7 @@ label nsfw_monika_sextingsession:
                     if not persistent._nsfw_sexting_interrupted:
                         $ mas_gainAffection(modifier=1.5, bypass=True)
                         $ persistent._nsfw_sexting_attempts = 1
+                    $ session_started = True
                     m 1hub "Yay~"
                     call nsfw_sexting_init
 
@@ -323,6 +327,7 @@ label nsfw_monika_sextingsession:
                     if not persistent._nsfw_sexting_interrupted:
                         $ mas_gainAffection(modifier=1.5, bypass=True)
                         $ persistent._nsfw_sexting_attempts = 1
+                    $ session_started = True
                     m 1hub "Yay~"
                     call nsfw_sexting_init
 
@@ -339,7 +344,7 @@ label nsfw_monika_sextingsession:
                         m 1eka "Okay, [player]."
 
         # Rejected 5+ times in a row
-        if too_many_attempts:
+        if too_many_attempts and session_started == False: # session_started prevents this block from triggering after saying yes
             # We're not punishing the player for this, but we also need to portray Monika's feelings somewhat accurately
             m 2dkd "*sign*"
             m 2ekc "[player], I give up."

--- a/game/Submods/NSFW Submod/nsfw_sexting_inits.rpy
+++ b/game/Submods/NSFW Submod/nsfw_sexting_inits.rpy
@@ -93,7 +93,7 @@ init 5 python:
                 "and mas_timePastSince(mas_getEVL_last_seen('nsfw_monika_sextingsession'), datetime.timedelta(hours=persistent._nsfw_monika_sexting_frequency)) "  # first possible repeat: 1/2/3/4 hours after last attempt
                 "and (mas_timePastSince(mas_getEVL_last_seen('nsfw_monika_sextingteaser'), datetime.timedelta(hours=2)) or persistent._nsfw_monika_sexting_frequency == 1)) " # teaser required if cooldown is not 3 hours
                 "or (persistent._nsfw_sexting_interrupted " # faster if last sexting session was interrupted:
-                "and persistent._nsfw_sexting_attempt_continue < 5 " # four attempts to restart an interrupted session
+                "and persistent._nsfw_sexting_attempt_continue < 5 " # five attempts to continue a session
                 "and mas_timePastSince(persistent._nsfw_last_sexted, datetime.timedelta(minutes=(15 * persistent._nsfw_monika_sexting_frequency))) " # 15, 30, 45 or 60 minutes after (enables sexy or hot start)
                 "and mas_timePastSince(mas_getEVL_last_seen('nsfw_monika_sextingsession'), datetime.timedelta(minutes=(15 * persistent._nsfw_monika_sexting_frequency + 5 * persistent._nsfw_monika_sexting_frequency * persistent._nsfw_sexting_attempt_continue))))" # repeat cooldown increases by 5, 10, 15 or 20 minutes, representing Monika’s patience
                 ),

--- a/game/Submods/NSFW Submod/nsfw_sexting_inits.rpy
+++ b/game/Submods/NSFW Submod/nsfw_sexting_inits.rpy
@@ -104,6 +104,8 @@ init 5 python:
 
 label nsfw_monika_sextingsession:
     # Count this attempt
+    if persistent._nsfw_sexting_attempts == 0: # necessary if the teaser was skipped due to the lowest cooldown setting
+        $ persistent._nsfw_sexting_attempts = 1
 
     python:
         #has_waited = ( # Checks if Monika has waited the correct amount of time to attempt to sext with the player -- obsolete --

--- a/game/Submods/NSFW Submod/nsfw_sexting_inits.rpy
+++ b/game/Submods/NSFW Submod/nsfw_sexting_inits.rpy
@@ -118,7 +118,7 @@ label nsfw_monika_sextingsession:
             persistent._nsfw_sexting_count = 1
 
         first_time = persistent._nsfw_sexting_count == 1 # Checks if the player has not sexting with Monika a second time
-        past_first_time = persistent._nsfw_sexting_count > 1 # Checks if the player has sexted with Monika more than once
+        past_first_time = persistent._nsfw_sexting_count > 1 and persistent._nsfw_sexting_count <= 5 # Checks if the player has sexted with Monika more than once
         veteran = persistent._nsfw_sexting_count > 5 # Checks if the player has sexted with Monika more than five times
 
         first_attempt = persistent._nsfw_sexting_attempts == 1 # Checks if it is Monika's first attempt to sext with the player

--- a/game/Submods/NSFW Submod/nsfw_sexting_inits.rpy
+++ b/game/Submods/NSFW Submod/nsfw_sexting_inits.rpy
@@ -88,14 +88,7 @@ init 5 python:
             #prompt="Being in the mood...",
             conditional=(
                 "mas_nsfw.can_monika_init_sext('nsfw_monika_sextingsession') "
-                "and (not persistent._nsfw_sexting_interrupted " # standard if the prior sexting session wasn’t interrupted by the player
-                "and mas_timePastSince(persistent._nsfw_sexting_success_last, datetime.timedelta(hours=(3 * 2 ** (persistent._nsfw_monika_sexting_frequency - 1)))) " # can be triggered if 3/6/12/24 hours have past since the last successful sexting session #SML
-                "and mas_timePastSince(mas_getEVL_last_seen('nsfw_monika_sextingsession'), datetime.timedelta(hours=persistent._nsfw_monika_sexting_frequency)) "  # first possible repeat: 1/2/3/4 hours after last attempt
-                "and ((mas_timePastSince(mas_getEVL_last_seen('nsfw_monika_sextingteaser'), datetime.timedelta(hours=2)) and mas_getEVL_last_seen('nsfw_monika_sextingteaser') != None) or persistent._nsfw_monika_sexting_frequency == 1)) " # teaser required if cooldown is not 3 hours
-                "or (persistent._nsfw_sexting_interrupted " # faster if last sexting session was interrupted:
-                "and persistent._nsfw_sexting_attempt_continue < 5 " # five attempts to continue a session
-                "and mas_timePastSince(persistent._nsfw_last_sexted, datetime.timedelta(minutes=(15 * persistent._nsfw_monika_sexting_frequency))) " # 15, 30, 45 or 60 minutes after (enables sexy or hot start)
-                "and mas_timePastSince(mas_getEVL_last_seen('nsfw_monika_sextingsession'), datetime.timedelta(minutes=(15 * persistent._nsfw_monika_sexting_frequency + 5 * persistent._nsfw_monika_sexting_frequency * persistent._nsfw_sexting_attempt_continue))))" # repeat cooldown increases by 5, 10, 15 or 20 minutes, representing Monika’s patience
+                "and mas_nsfw.has_monika_waited()"
                 ),
             action=EV_ACT_RANDOM,
             aff_range=(mas_aff.LOVE, None)
@@ -103,7 +96,7 @@ init 5 python:
     )
 
 label nsfw_monika_sextingsession:
-    
+    # Count this attempt
     if persistent._nsfw_sexting_attempts == 0: # necessary if the teaser was skipped due to the lowest cooldown setting or interrupted sexting session
         $ persistent._nsfw_sexting_attempts = 1
 
@@ -127,8 +120,7 @@ label nsfw_monika_sextingsession:
         hot_start = persistent._nsfw_sext_hot_start # Checks if the player has interrupted Monika's last sexting session during the 'hot' stage
         sexy_start = persistent._nsfw_sext_sexy_start # Checks if the player has interrupted Monika's last sexting session during the 'sexy' stage
 
-    # Count this attempt -- moved here because of the teaser
-    $ persistent._nsfw_sexting_attempts += 1
+    $ persistent._nsfw_sexting_attempts += 1 # moved here because of the teaser
     if persistent._nsfw_sexting_attempt_continue < 5 and persistent._nsfw_sexting_interrupted:
         $ persistent._nsfw_sexting_attempt_continue += 1 # raise the cooldown each time after an interrupted session
 
@@ -370,7 +362,7 @@ label nsfw_monika_sextingteaser_end:
     python:
         with MAS_EVL("nsfw_monika_sextingteaser") as sextingteaser_ev:
             sextingteaser_ev.random = False
-            sextingteaser_ev.conditional = (
+            sextingteaser_ev.conditional=(
                 "mas_nsfw.can_monika_init_sext('nsfw_monika_sextingteaser') "
                 "and mas_timePastSince(persistent._nsfw_sexting_success_last, datetime.timedelta(hours=(3 * 2 ** (persistent._nsfw_monika_sexting_frequency - 1)) - 2)) " # can be triggered 2 hours before cooldown end #SML
                 "and persistent._nsfw_monika_sexting_frequency != 1 " # no teaser if cooldown is set to only 3 hours
@@ -382,20 +374,12 @@ label nsfw_monika_sextingteaser_end:
     return
 
 label nsfw_monika_sextingsession_end:
-    # Copy of monika_holdme_end label
     python:
         with MAS_EVL("nsfw_monika_sextingsession") as sextingsession_ev:
             sextingsession_ev.random = False
-            sextingsession_ev.conditional = (
+            sextingsession_ev.conditional=(
                 "mas_nsfw.can_monika_init_sext('nsfw_monika_sextingsession') "
-                "and (not persistent._nsfw_sexting_interrupted " # standard if the prior sexting session wasn’t interrupted by the player
-                "and mas_timePastSince(persistent._nsfw_sexting_success_last, datetime.timedelta(hours=(3 * 2 ** (persistent._nsfw_monika_sexting_frequency - 1)))) " # can be triggered if 3/6/12/24 hours have past since the last successful sexting session #SML
-                "and mas_timePastSince(mas_getEVL_last_seen('nsfw_monika_sextingsession'), datetime.timedelta(hours=persistent._nsfw_monika_sexting_frequency)) "  # first possible repeat: 1/2/3/4 hours after last attempt
-                "and ((mas_timePastSince(mas_getEVL_last_seen('nsfw_monika_sextingteaser'), datetime.timedelta(hours=2)) and mas_getEVL_last_seen('nsfw_monika_sextingteaser') != None) or persistent._nsfw_monika_sexting_frequency == 1)) " # teaser required if cooldown is not 3 hours
-                "or (persistent._nsfw_sexting_interrupted " # faster if last sexting session was interrupted:
-                "and persistent._nsfw_sexting_attempt_continue < 5 " # four attempts to restart an interrupted session
-                "and mas_timePastSince(persistent._nsfw_last_sexted, datetime.timedelta(minutes=(15 * persistent._nsfw_monika_sexting_frequency))) " # 15, 30, 45 or 60 minutes after (enables sexy or hot start)
-                "and mas_timePastSince(mas_getEVL_last_seen('nsfw_monika_sextingsession'), datetime.timedelta(minutes=(15 * persistent._nsfw_monika_sexting_frequency + 5 * persistent._nsfw_monika_sexting_frequency * persistent._nsfw_sexting_attempt_continue))))" # repeat cooldown increases by 5, 10, 15 or 20 minutes, representing Monika’s patience
+                "and mas_nsfw.has_monika_waited()"
                 )
             sextingsession_ev.action = EV_ACT_RANDOM
         mas_rebuildEventLists()

--- a/game/Submods/NSFW Submod/nsfw_sexting_inits.rpy
+++ b/game/Submods/NSFW Submod/nsfw_sexting_inits.rpy
@@ -103,8 +103,8 @@ init 5 python:
     )
 
 label nsfw_monika_sextingsession:
-    # Count this attempt
-    if persistent._nsfw_sexting_attempts == 0: # necessary if the teaser was skipped due to the lowest cooldown setting
+    
+    if persistent._nsfw_sexting_attempts == 0: # necessary if the teaser was skipped due to the lowest cooldown setting or interrupted sexting session
         $ persistent._nsfw_sexting_attempts = 1
 
     python:
@@ -127,7 +127,8 @@ label nsfw_monika_sextingsession:
         hot_start = persistent._nsfw_sext_hot_start # Checks if the player has interrupted Monika's last sexting session during the 'hot' stage
         sexy_start = persistent._nsfw_sext_sexy_start # Checks if the player has interrupted Monika's last sexting session during the 'sexy' stage
 
-    $ persistent._nsfw_sexting_attempts += 1 # moved here because of the teaser
+    # Count this attempt -- moved here because of the teaser
+    $ persistent._nsfw_sexting_attempts += 1
     if persistent._nsfw_sexting_attempt_continue < 5 and persistent._nsfw_sexting_interrupted:
         $ persistent._nsfw_sexting_attempt_continue += 1 # raise the cooldown each time after an interrupted session
 

--- a/game/Submods/NSFW Submod/nsfw_sexting_inits.rpy
+++ b/game/Submods/NSFW Submod/nsfw_sexting_inits.rpy
@@ -25,6 +25,8 @@ init 5 python:
     )
 
 label nsfw_player_sextingsession:
+    $ success = False # True if sexting session was successfully finished
+
     # Check when player's last succesful sexting session was
     if store.persistent._nsfw_sexting_success_last is not None:
         $ timedelta_of_last_success = datetime.datetime.now() - store.persistent._nsfw_sexting_success_last
@@ -42,6 +44,9 @@ label nsfw_player_sextingsession:
     m 1hua "Sure!"
 
     call nsfw_sexting_init
+
+    if success == True: # Monika ends successful sexting session with "I love you"
+        return "love"
 
     return
 
@@ -96,6 +101,8 @@ init 5 python:
     )
 
 label nsfw_monika_sextingsession:
+    $ success = False # True if sexting session was successfully finished
+
     # Count this attempt
     if persistent._nsfw_sexting_attempts == 0: # necessary if the teaser was skipped due to the lowest cooldown setting or interrupted sexting session
         $ persistent._nsfw_sexting_attempts = 1
@@ -354,6 +361,9 @@ label nsfw_monika_sextingsession:
     #    m 5hubla "Ehehe~"
 
     call nsfw_monika_sextingsession_end
+
+    if success == True:
+        return "love|no_unlock"
 
     return "no_unlock"
 

--- a/game/Submods/NSFW Submod/nsfw_sexting_inits.rpy
+++ b/game/Submods/NSFW Submod/nsfw_sexting_inits.rpy
@@ -1,3 +1,9 @@
+# Parameters for Monika
+default persistent._nsfw_sexting_attempts = 0 # Number of times Monika has attempted to sext with the player
+default persistent._nsfw_sexting_attempt_freeze = False # If Monika is currently frozen from attempting to sext with the player
+default persistent._nsfw_sexting_attempt_permfreeze = False # If Monika is permanently frozen from attempting to sext with the player
+default persistent._nsfw_sexting_attempt_continue = 0 # Number of times Monika has attempted to continue an interrupted session
+
 # PLAYER
 
 init 5 python:
@@ -41,19 +47,55 @@ label nsfw_player_sextingsession:
 
 # MONIKA
 
-default persistent._nsfw_sexting_attempts = 0 # Number of times Monika has attempted to sext with the player
-default persistent._nsfw_sexting_attempt_freeze = False # If Monika is currently frozen from attempting to sext with the player
-default persistent._nsfw_sexting_attempt_permfreeze = False # If Monika is permanently frozen from attempting to sext with the player
+init 5 python:
+    addEvent(
+        Event(
+            persistent.event_database,
+            eventlabel="nsfw_monika_sextingteaser",
+            conditional=(
+                "mas_nsfw.can_monika_init_sext('nsfw_monika_sextingteaser') "
+                "and mas_timePastSince(persistent._nsfw_sexting_success_last, datetime.timedelta(hours=(3 * 2 ** (persistent._nsfw_monika_sexting_frequency - 1)) - 2)) " # can be triggered 2 hours before cooldown end #SML
+                "and persistent._nsfw_monika_sexting_frequency != 1 " # no teaser if cooldown is set to only 3 hours
+                "and persistent._nsfw_sexting_attempts == 0 " # only one teaser each cycle
+                "and not persistent._nsfw_sexting_interrupted" # no teaser after interruption, just a fallback, attempts shouldn’t be 0 at this point
+                ),
+            action=EV_ACT_RANDOM,
+            aff_range=(mas_aff.LOVE, None)
+        )
+    )
+
+label nsfw_monika_sextingteaser: # alternative dialogue would be welcome #SML
+
+    $ persistent._nsfw_sexting_attempts += 1 # prevents another teaser triggering
+
+    m 1tua "Hey, [mas_get_player_nickname()]~"
+    m 3tubla "Just wanted to let you know that I might be in the mood for some {i}fun{/i} later."
+    m 3tublb "I hope you're free then~"
+    m 5tublb "Or we could just do it right now, if you're up for it~"
+    m 5gublb "I'm sure you'll be able to make time for me, right?"
+    m 5hubla "Ehehe~"    
+
+    call nsfw_monika_sextingteaser_end
+    return "no_unlock"
+
 
 init 5 python:
     addEvent(
         Event(
             persistent.event_database,
             eventlabel="nsfw_monika_sextingsession",
+            #category=['sex'], # for testing purposes
+            #prompt="Being in the mood...",
             conditional=(
                 "mas_nsfw.can_monika_init_sext('nsfw_monika_sextingsession') "
-                "and mas_timePastSince(persistent._nsfw_sexting_last_sexted, datetime.timedelta(hours=persistent._nsfw_monika_sexting_frequency * 12)) "
-                "and mas_timePastSince(mas_getEVL_last_seen('nsfw_monika_sextingsession'), datetime.timedelta(hours=persistent._nsfw_monika_sexting_frequency * 12))"
+                "and (not persistent._nsfw_sexting_interrupted " # standard if the prior sexting session wasn’t interrupted by the player
+                "and mas_timePastSince(persistent._nsfw_sexting_success_last, datetime.timedelta(hours=(3 * 2 ** (persistent._nsfw_monika_sexting_frequency - 1)))) " # can be triggered if 3/6/12/24 hours have past since the last successful sexting session #SML
+                "and mas_timePastSince(mas_getEVL_last_seen('nsfw_monika_sextingsession'), datetime.timedelta(hours=persistent._nsfw_monika_sexting_frequency)) "  # first possible repeat: 1/2/3/4 hours after last attempt
+                "and (mas_timePastSince(mas_getEVL_last_seen('nsfw_monika_sextingteaser'), datetime.timedelta(hours=2)) or persistent._nsfw_monika_sexting_frequency == 1)) " # teaser required if cooldown is not 3 hours
+                "or (persistent._nsfw_sexting_interrupted " # faster if last sexting session was interrupted:
+                "and persistent._nsfw_sexting_attempt_continue < 5 " # four attempts to restart an interrupted session
+                "and mas_timePastSince(persistent._nsfw_last_sexted, datetime.timedelta(minutes=(15 * persistent._nsfw_monika_sexting_frequency))) " # 15, 30, 45 or 60 minutes after (enables sexy or hot start)
+                "and mas_timePastSince(mas_getEVL_last_seen('nsfw_monika_sextingsession'), datetime.timedelta(minutes=(15 * persistent._nsfw_monika_sexting_frequency + 5 * persistent._nsfw_monika_sexting_frequency * persistent._nsfw_sexting_attempt_continue))))" # repeat cooldown increases by 5, 10, 15 or 20 minutes, representing Monika’s patience
                 ),
             action=EV_ACT_RANDOM,
             aff_range=(mas_aff.LOVE, None)
@@ -62,13 +104,12 @@ init 5 python:
 
 label nsfw_monika_sextingsession:
     # Count this attempt
-    $ persistent._nsfw_sexting_attempts += 1
 
     python:
-        has_waited = ( # Checks if Monika has waited the correct amount of time to attempt to sext with the player
-            persistent._nsfw_sexting_attempts >= persistent._nsfw_monika_sexting_frequency
-            and persistent._nsfw_sexting_attempts % persistent._nsfw_monika_sexting_frequency == 0
-            )
+        #has_waited = ( # Checks if Monika has waited the correct amount of time to attempt to sext with the player -- obsolete --
+        #    persistent._nsfw_sexting_attempts >= persistent._nsfw_monika_sexting_frequency #SML necessary? attempts can’t be 0 at this point
+        #    and persistent._nsfw_sexting_attempts % persistent._nsfw_monika_sexting_frequency == 0
+        #    )
 
         # Topic cannot run unless player has succesfully sexted with Monika, so a count of 0 whilst at this point is very unlikely.
         if persistent._nsfw_sexting_count == 0 and persistent._nsfw_sexting_success_last is not None:
@@ -80,9 +121,13 @@ label nsfw_monika_sextingsession:
 
         first_attempt = persistent._nsfw_sexting_attempts == 1 # Checks if it is Monika's first attempt to sext with the player
         multiple_attempts = persistent._nsfw_sexting_attempts > 1 # Checks if Monika has attempted to sext with the player more than once
-        too_many_attempts = persistent._nsfw_sexting_attempts >= 5 * persistent._nsfw_monika_sexting_frequency # Checks if Monika has attempted to sext with the player more than four times
+        too_many_attempts = persistent._nsfw_sexting_attempts >= 5 # Checks if Monika has attempted to sext with the player more than four times
         hot_start = persistent._nsfw_sext_hot_start # Checks if the player has interrupted Monika's last sexting session during the 'hot' stage
         sexy_start = persistent._nsfw_sext_sexy_start # Checks if the player has interrupted Monika's last sexting session during the 'sexy' stage
+
+    $ persistent._nsfw_sexting_attempts += 1 # moved here because of the teaser
+    if persistent._nsfw_sexting_attempt_continue < 5 and persistent._nsfw_sexting_interrupted:
+        $ persistent._nsfw_sexting_attempt_continue += 1 # raise the cooldown each time after an interrupted session
 
     # Reset our freeze if it's been 12 hours (or 24 if you set to low sexting frequency) since the last sexting attempt
     if persistent._nsfw_sexting_attempt_freeze == True:
@@ -97,8 +142,9 @@ label nsfw_monika_sextingsession:
             m "Are you available now?{fast}"
 
             "Yes.":
-                $ mas_gainAffection(modifier=1.5, bypass=True)
-                $ persistent._nsfw_sexting_attempts = 0
+                if not persistent._nsfw_sexting_interrupted: # prevents exploitation of the reduced cooldown after interruption, also makes sure the player cannot interrupt sexting too often
+                    $ mas_gainAffection(modifier=1.5, bypass=True)
+                    $ persistent._nsfw_sexting_attempts = 1 # has to be set to 1 due to the teaser modifications
                 m 1hub "Yay~"
                 call nsfw_sexting_init
 
@@ -107,7 +153,8 @@ label nsfw_monika_sextingsession:
                 m 1ekb "Maybe next time, then."
 
     # If our number of attempts is greater than or equal to the player's frequency request and they divide into each other perfectly, then try to sext
-    elif has_waited:
+    #elif has_waited: -- obsolete -- SML
+    else:
         # First time
         if first_time:
             m 1gua "Hey, [player]..."
@@ -144,8 +191,9 @@ label nsfw_monika_sextingsession:
                 m "[sexting_starter]{fast}"
 
                 "Yes.":
-                    $ mas_gainAffection(modifier=1.5, bypass=True)
-                    $ persistent._nsfw_sexting_attempts = 0
+                    if not persistent._nsfw_sexting_interrupted:
+                        $ mas_gainAffection(modifier=1.5, bypass=True)
+                        $ persistent._nsfw_sexting_attempts = 1
                     m 1hub "Yay~"
                     call nsfw_sexting_init
 
@@ -160,6 +208,7 @@ label nsfw_monika_sextingsession:
                     if not too_many_attempts:
                         m 1ekc "Aww..."
                         m 1eka "Okay, [player]."
+                        
 
         # First 5 times (after one success)
         elif past_first_time:
@@ -195,8 +244,9 @@ label nsfw_monika_sextingsession:
                 m "[sexting_starter]{fast}"
 
                 "Yes.":
-                    $ mas_gainAffection(modifier=1.5, bypass=True)
-                    $ persistent._nsfw_sexting_attempts = 0
+                    if not persistent._nsfw_sexting_interrupted:
+                        $ mas_gainAffection(modifier=1.5, bypass=True)
+                        $ persistent._nsfw_sexting_attempts = 1
                     m 1hub "Yay~"
                     call nsfw_sexting_init
 
@@ -268,8 +318,9 @@ label nsfw_monika_sextingsession:
                 m "[sexting_starter]{fast}"
 
                 "Yes.":
-                    $ mas_gainAffection(modifier=1.5, bypass=True)
-                    $ persistent._nsfw_sexting_attempts = 0
+                    if not persistent._nsfw_sexting_interrupted:
+                        $ mas_gainAffection(modifier=1.5, bypass=True)
+                        $ persistent._nsfw_sexting_attempts = 1
                     m 1hub "Yay~"
                     call nsfw_sexting_init
 
@@ -299,17 +350,33 @@ label nsfw_monika_sextingsession:
 
             $ persistent._nsfw_sexting_attempt_permfreeze = True # This should be reversable
 
-    else:
-        m 1tua "Hey, [mas_get_player_nickname()]~"
-        m 3tubla "Just wanted to let you know that in the mood for some {i}fun{/i} later."
-        m 3tublb "I hope you're free then~"
-        m 5tublb "Or we could just do it right now, if you're up for it~"
-        m 5gublb "I'm sure you'll be able to make time for me, right?"
-        m 5hubla "Ehehe~"
+    #else: -- obsolete, now in nsfw_monika_sextingteaser --
+    #    m 1tua "Hey, [mas_get_player_nickname()]~"
+    #    m 3tubla "Just wanted to let you know that in the mood for some {i}fun{/i} later."
+    #    m 3tublb "I hope you're free then~"
+    #    m 5tublb "Or we could just do it right now, if you're up for it~"
+    #    m 5gublb "I'm sure you'll be able to make time for me, right?"
+    #    m 5hubla "Ehehe~"
 
     call nsfw_monika_sextingsession_end
 
     return "no_unlock"
+
+label nsfw_monika_sextingteaser_end:
+    # Copy of monika_holdme_end label
+    python:
+        with MAS_EVL("nsfw_monika_sextingteaser") as sextingteaser_ev:
+            sextingteaser_ev.random = False
+            sextingteaser_ev.conditional = (
+                "mas_nsfw.can_monika_init_sext('nsfw_monika_sextingteaser') "
+                "and mas_timePastSince(persistent._nsfw_sexting_success_last, datetime.timedelta(hours=(3 * 2 ** (persistent._nsfw_monika_sexting_frequency - 1)) - 2)) " # can be triggered 2 hours before cooldown end #SML
+                "and persistent._nsfw_monika_sexting_frequency != 1 " # no teaser if cooldown is set to only 3 hours
+                "and persistent._nsfw_sexting_attempts == 0 " # only one teaser each cycle
+                "and not persistent._nsfw_sexting_interrupted" # no teaser after interruption, just a fallback, attempts shouldn’t be 0 at this point
+                )
+            sextingteaser_ev.action = EV_ACT_RANDOM
+        mas_rebuildEventLists()
+    return
 
 label nsfw_monika_sextingsession_end:
     # Copy of monika_holdme_end label
@@ -318,9 +385,16 @@ label nsfw_monika_sextingsession_end:
             sextingsession_ev.random = False
             sextingsession_ev.conditional = (
                 "mas_nsfw.can_monika_init_sext('nsfw_monika_sextingsession') "
-                "and mas_timePastSince(persistent._nsfw_sexting_last_sexted, datetime.timedelta(hours=persistent._nsfw_monika_sexting_frequency * 12)) "
-                "and mas_timePastSince(mas_getEVL_last_seen('nsfw_monika_sextingsession'), datetime.timedelta(hours=persistent._nsfw_monika_sexting_frequency * 12))"
-            )
+                "and (not persistent._nsfw_sexting_interrupted " # standard if the prior sexting session wasn’t interrupted by the player
+                "and mas_timePastSince(persistent._nsfw_sexting_success_last, datetime.timedelta(hours=(3 * 2 ** (persistent._nsfw_monika_sexting_frequency - 1)))) " # can be triggered if 3/6/12/24 hours have past since the last successful sexting session #SML
+                "and mas_timePastSince(mas_getEVL_last_seen('nsfw_monika_sextingsession'), datetime.timedelta(hours=persistent._nsfw_monika_sexting_frequency)) "  # first possible repeat: 1/2/3/4 hours after last attempt
+                "and (mas_timePastSince(mas_getEVL_last_seen('nsfw_monika_sextingteaser'), datetime.timedelta(hours=2)) or persistent._nsfw_monika_sexting_frequency == 1)) " # teaser required if cooldown is not 3 hours
+                "or (persistent._nsfw_sexting_interrupted " # faster if last sexting session was interrupted:
+                "and persistent._nsfw_sexting_attempt_continue < 5 " # four attempts to restart an interrupted session
+                "and mas_timePastSince(persistent._nsfw_last_sexted, datetime.timedelta(minutes=(15 * persistent._nsfw_monika_sexting_frequency))) " # 15, 30, 45 or 60 minutes after (enables sexy or hot start)
+                "and mas_timePastSince(mas_getEVL_last_seen('nsfw_monika_sextingsession'), datetime.timedelta(minutes=(15 * persistent._nsfw_monika_sexting_frequency + 5 * persistent._nsfw_monika_sexting_frequency * persistent._nsfw_sexting_attempt_continue))))" # repeat cooldown increases by 5, 10, 15 or 20 minutes, representing Monika’s patience
+                )
             sextingsession_ev.action = EV_ACT_RANDOM
         mas_rebuildEventLists()
+    
     return

--- a/game/Submods/NSFW Submod/nsfw_sexting_inits.rpy
+++ b/game/Submods/NSFW Submod/nsfw_sexting_inits.rpy
@@ -59,12 +59,12 @@ init 5 python:
             eventlabel="nsfw_monika_sextingteaser",
             conditional=(
                 "mas_nsfw.can_monika_init_sext('nsfw_monika_sextingteaser') "
-                "and mas_timePastSince(persistent._nsfw_sexting_success_last, datetime.timedelta(hours=(3 * 2 ** (persistent._nsfw_monika_sexting_frequency - 1)) - 2)) " # can be triggered 2 hours before cooldown end #SML
-                "and persistent._nsfw_monika_sexting_frequency != 1 " # no teaser if cooldown is set to only 3 hours
+                "and mas_timePastSince(persistent._nsfw_sexting_success_last, datetime.timedelta(hours=(3 * 2 ** persistent._nsfw_monika_sexting_frequency - 2))) " # can be triggered 2 hours before cooldown end #SML
+                "and persistent._nsfw_monika_sexting_frequency != 0 " # no teaser if cooldown is set to only 3 hours
                 "and persistent._nsfw_sexting_attempts == 0 " # only one teaser each cycle
                 "and not persistent._nsfw_sexting_interrupted" # no teaser after interruption, just a fallback, attempts shouldn’t be 0 at this point
                 ),
-            action=EV_ACT_RANDOM,
+            action=EV_ACT_QUEUE,
             aff_range=(mas_aff.LOVE, None)
         )
     )
@@ -95,7 +95,7 @@ init 5 python:
                 "mas_nsfw.can_monika_init_sext('nsfw_monika_sextingsession') "
                 "and mas_nsfw.has_monika_waited()"
                 ),
-            action=EV_ACT_RANDOM,
+            action=EV_ACT_QUEUE,
             aff_range=(mas_aff.LOVE, None)
         )
     )
@@ -128,7 +128,7 @@ label nsfw_monika_sextingsession:
         sexy_start = persistent._nsfw_sext_sexy_start # Checks if the player has interrupted Monika's last sexting session during the 'sexy' stage
 
     $ persistent._nsfw_sexting_attempts += 1 # moved here because of the teaser
-    if persistent._nsfw_sexting_attempt_continue < 5 and persistent._nsfw_sexting_interrupted:
+    if persistent._nsfw_sexting_attempt_continue < 4 and persistent._nsfw_sexting_interrupted:
         $ persistent._nsfw_sexting_attempt_continue += 1 # raise the cooldown each time after an interrupted session
 
     # Reset our freeze if it's been 12 hours (or 24 if you set to low sexting frequency) since the last sexting attempt
@@ -374,12 +374,12 @@ label nsfw_monika_sextingteaser_end:
             sextingteaser_ev.random = False
             sextingteaser_ev.conditional=(
                 "mas_nsfw.can_monika_init_sext('nsfw_monika_sextingteaser') "
-                "and mas_timePastSince(persistent._nsfw_sexting_success_last, datetime.timedelta(hours=(3 * 2 ** (persistent._nsfw_monika_sexting_frequency - 1)) - 2)) " # can be triggered 2 hours before cooldown end #SML
-                "and persistent._nsfw_monika_sexting_frequency != 1 " # no teaser if cooldown is set to only 3 hours
+                "and mas_timePastSince(persistent._nsfw_sexting_success_last, datetime.timedelta(hours=(3 * 2 ** persistent._nsfw_monika_sexting_frequency - 2))) " # can be triggered 2 hours before cooldown end #SML
+                "and persistent._nsfw_monika_sexting_frequency != 0 " # no teaser if cooldown is set to only 3 hours
                 "and persistent._nsfw_sexting_attempts == 0 " # only one teaser each cycle
                 "and not persistent._nsfw_sexting_interrupted" # no teaser after interruption, just a fallback, attempts shouldn’t be 0 at this point
                 )
-            sextingteaser_ev.action = EV_ACT_RANDOM
+            sextingteaser_ev.action = EV_ACT_QUEUE
         mas_rebuildEventLists()
     return
 
@@ -391,7 +391,7 @@ label nsfw_monika_sextingsession_end:
                 "mas_nsfw.can_monika_init_sext('nsfw_monika_sextingsession') "
                 "and mas_nsfw.has_monika_waited()"
                 )
-            sextingsession_ev.action = EV_ACT_RANDOM
+            sextingsession_ev.action = EV_ACT_QUEUE
         mas_rebuildEventLists()
     
     return

--- a/game/Submods/NSFW Submod/nsfw_sexting_inits.rpy
+++ b/game/Submods/NSFW Submod/nsfw_sexting_inits.rpy
@@ -91,7 +91,7 @@ init 5 python:
                 "and (not persistent._nsfw_sexting_interrupted " # standard if the prior sexting session wasn’t interrupted by the player
                 "and mas_timePastSince(persistent._nsfw_sexting_success_last, datetime.timedelta(hours=(3 * 2 ** (persistent._nsfw_monika_sexting_frequency - 1)))) " # can be triggered if 3/6/12/24 hours have past since the last successful sexting session #SML
                 "and mas_timePastSince(mas_getEVL_last_seen('nsfw_monika_sextingsession'), datetime.timedelta(hours=persistent._nsfw_monika_sexting_frequency)) "  # first possible repeat: 1/2/3/4 hours after last attempt
-                "and (mas_timePastSince(mas_getEVL_last_seen('nsfw_monika_sextingteaser'), datetime.timedelta(hours=2)) or persistent._nsfw_monika_sexting_frequency == 1)) " # teaser required if cooldown is not 3 hours
+                "and ((mas_timePastSince(mas_getEVL_last_seen('nsfw_monika_sextingteaser'), datetime.timedelta(hours=2)) and mas_getEVL_last_seen('nsfw_monika_sextingteaser') != None) or persistent._nsfw_monika_sexting_frequency == 1)) " # teaser required if cooldown is not 3 hours
                 "or (persistent._nsfw_sexting_interrupted " # faster if last sexting session was interrupted:
                 "and persistent._nsfw_sexting_attempt_continue < 5 " # five attempts to continue a session
                 "and mas_timePastSince(persistent._nsfw_last_sexted, datetime.timedelta(minutes=(15 * persistent._nsfw_monika_sexting_frequency))) " # 15, 30, 45 or 60 minutes after (enables sexy or hot start)
@@ -391,7 +391,7 @@ label nsfw_monika_sextingsession_end:
                 "and (not persistent._nsfw_sexting_interrupted " # standard if the prior sexting session wasn’t interrupted by the player
                 "and mas_timePastSince(persistent._nsfw_sexting_success_last, datetime.timedelta(hours=(3 * 2 ** (persistent._nsfw_monika_sexting_frequency - 1)))) " # can be triggered if 3/6/12/24 hours have past since the last successful sexting session #SML
                 "and mas_timePastSince(mas_getEVL_last_seen('nsfw_monika_sextingsession'), datetime.timedelta(hours=persistent._nsfw_monika_sexting_frequency)) "  # first possible repeat: 1/2/3/4 hours after last attempt
-                "and (mas_timePastSince(mas_getEVL_last_seen('nsfw_monika_sextingteaser'), datetime.timedelta(hours=2)) or persistent._nsfw_monika_sexting_frequency == 1)) " # teaser required if cooldown is not 3 hours
+                "and ((mas_timePastSince(mas_getEVL_last_seen('nsfw_monika_sextingteaser'), datetime.timedelta(hours=2)) and mas_getEVL_last_seen('nsfw_monika_sextingteaser') != None) or persistent._nsfw_monika_sexting_frequency == 1)) " # teaser required if cooldown is not 3 hours
                 "or (persistent._nsfw_sexting_interrupted " # faster if last sexting session was interrupted:
                 "and persistent._nsfw_sexting_attempt_continue < 5 " # four attempts to restart an interrupted session
                 "and mas_timePastSince(persistent._nsfw_last_sexted, datetime.timedelta(minutes=(15 * persistent._nsfw_monika_sexting_frequency))) " # 15, 30, 45 or 60 minutes after (enables sexy or hot start)

--- a/game/Submods/NSFW Submod/nsfw_window_reacts.rpy
+++ b/game/Submods/NSFW Submod/nsfw_window_reacts.rpy
@@ -45,7 +45,7 @@ label nsfw_wrs_r34:
                 else:
                     exp_to_force = "2tssdlc"
 
-        store.mas_moni_idle_disp.force_by_code(exp_to_force, duration=10)
+            store.mas_moni_idle_disp.force_by_code(exp_to_force, duration=10)
     return
 
 init 5 python:


### PR DESCRIPTION
### UPDATE: Sexting inits

Looking for the bug that prevented Monika from starting a sexting session, I made a lot of other additions in order to make this feature more intuitive.

First things first: The major bug has been fixed. It was in the conditions:

```
init 5 python:
    addEvent(
        Event(
            persistent.event_database,
            eventlabel="nsfw_monika_sextingsession",
            conditional=(
                "mas_nsfw.can_monika_init_sext('nsfw_monika_sextingsession') "
                "and mas_timePastSince(persistent._nsfw_sexting_last_sexted, datetime.timedelta(hours=12 * persistent._nsfw_monika_sexting_frequency))) "
                "and mas_timePastSince(mas_getEVL_last_seen('nsfw_monika_sextingsession'), datetime.timedelta(hours=12 * persistent._nsfw_monika_sexting_frequency)))"
                ),
            action=EV_ACT_RANDOM,
            aff_range=(mas_aff.LOVE, None)
        )
    )
```
In nsfw_sexting.rpy, the timestamp at the end of a sexting session has the label `persistent._nsfw_last_sexted`, but in nsfw_sexting_inits.rpy, it was `persistent._nsfw_sexting_last_sexted`. All this time it has been checking for a parameter that doesn’t exist, so of course the condition could never be true.

Furthermore, I added more cooldown options so the player could now choose whether Monika will wait 3, 6, 12, 24 or 48 hours after a successful sexting session before asking for another, with the `mas_timePastSince()` parameter being `persistent._nsfw_sexting_success_last` rather than `persistent._nsfw_last_sexted`. Since 3 hours is the same amount the player has to wait before they can ask her for another session, this seems like a fair minimum value. After the first time if she has been rejected, she will make another attempt every 1/2/4/8/16 hours until you give her what she wants or she gives up after the 5th time.

Since the has_waited check however didn’t really work as intended, what I did instead was turning the “announcement” dialogue into a separate event `nsfw_monika_sextingteaser` with its own trigger conditions. The teaser can trigger two hours before Monika has waited long enough after a successful sexting session, and it is conditional for the actual request unless the cooldown is set to 3 hours. Since I used the `persistent._nsfw_sexting_attempts` parameter to determine whether the teaser can be triggered or not, I had to make some adjustments so if the player accepts Monika’s sexting request, the value will be set to 1 rather than 0. Only when a sexting session is successfully finished, the parameter will be set to 0. If you want to add more possible dialogue that could be randomly picked, be my guest.

But this is not the end. In order to spice things up and actually put the hot/sexy start dialogue to a good use (since before they could only trigger when her horny level was already at rock bottom again), I defined different conditions in case that the event is triggered after the player interrupted a sexting session, finally making use of that `persistent._nsfw_sexting_interrupted` parameter as well. If that happens, Monika will wait 15, 30, 45, 60 or 75 minutes before she attempts to restart the interrupted session, and then it will increase by 5 minutes after each attempt. So, let’s say, you set the cooldown to 6 hours. In that case, after interrupting a sexting session, Monika can make her first attempt to continue it after 30 minutes, the second one 35 minutes later (= 65 minutes after you stopped the session) and so on. Basically each time you reject her, she tries to be a bit more patient next time but her lust also decreases. But this also means that if you set her cooldown to the lowest possible setting, she _is_ **really** horny and you cannot let her wait for too long.

However, in order to avoid exploitation of that mechanic, whenever you agree to Monika’s sexting request, you will only gain affection and reset her attempt counter if your last sexting session wasn’t interrupted. That way you can’t interrupt a sexting session too often or she will just hit the `too_many_attempts` threshold and give up as she does after being rejected too often. Still missing at this point is a proper reaction of hers after you interrupted the same sexting session too often in a row, so technically there is still a loophole.

Did I miss something about this? Most likely, and there are probably still some dispensable conditions or commands I just missed. Nevertheless I’m glad to have finally found the init bug and to add some improvements.

**### _Clothes props and selection_**

In nsfw_birthday_suit.rpy, the properties
```
store.mas_sprites.EXP_C_BS: True,
store.mas_sprites.EXP_C_WET: True,
store.mas_sprites.EXP_C_C_DTS: True
```
have been added to the birthday suit and underwear. The first two properties will make them compatible with Monika’s hair being wet when she greets you right after returning from the shower (or bath); which means you can sext with her right away and her hair will stay wet rather than automatically changing to her standard ponytail when she undresses. The third property does the same for the “Down (Tied strand)” hairstyle that comes with her Marisa (witch) Halloween costume.

As for the updates in nsfw_sexting.rpy, two major features have been added:

1. Instead of always changing to her white underwear, Monika will now randomly pick black and pink as well if they have been unlocked.
2. If Monika completely undresses at any point and finishes in that state, her end dialogue after climax will be slightly different and she won’t change since she (obviously) doesn’t wear any sweaty clothes she needs to get out of. It wasn’t my primary intention to submit this, but since it was already in my code, here we are. However this could probably use some more refinement, like different dialogue lines or a timer that will make her put on some clothes after like 20 minutes rather than staying nude until the player closes the game, similar to her wearing her towel after the bath/shower greeting.

Additionally, the player can now scream out loud Monika’s name in-game when climaxing.

The birthday suit/underwear additions have been tested and are working properly. The new sexting inits worked under testing conditions, but how they work with the actual timer/cooldown settings remains to be seen.

Update: Monika’s announcement and sexting attempts work as intended now.